### PR TITLE
Version0 development cgaustin

### DIFF
--- a/api/domain/mock_order.py
+++ b/api/domain/mock_order.py
@@ -1,0 +1,42 @@
+from api.utils import api_cfg
+from api.dbconnect import DBConnect
+from api.domain.order import Order
+from api.domain.scene import Scene
+from api.api_logging import api_logger as logger
+from psycopg2.extras import Json
+import datetime
+import os
+
+cfg = api_cfg()
+
+class MockOrderException(Exception):
+    pass
+
+class MockOrder(Order):
+    """ Class for interacting with the ordering_order table """
+
+    def __init__(self, **kwargs):
+        super(MockOrder, self).__init__(**kwargs)
+        try:
+            mode = os.environ["espa_api_testing"]
+            if mode is not "True":
+                raise("MockOrder objects only allowed while testing")
+        except:
+            raise MockOrderException("MockOrder objects only allowed while testing")
+
+    def __repr__(self):
+        return "MockOrder:{0}".format(self.__dict__)
+
+    @classmethod
+    def generate_testing_orders(cls):
+        # this is the method I'd use to add
+        # a number of dummy orders into the test db
+        pass
+
+    @classmethod
+    def tear_down_testing_orders(cls):
+        # method for tearing down orders
+        # used for testing
+        pass
+
+

--- a/api/domain/mock_order.py
+++ b/api/domain/mock_order.py
@@ -7,8 +7,6 @@ from psycopg2.extras import Json
 import datetime
 import os
 
-cfg = api_cfg()
-
 class MockOrderException(Exception):
     pass
 
@@ -23,6 +21,8 @@ class MockOrder(Order):
                 raise("MockOrder objects only allowed while testing")
         except:
             raise MockOrderException("MockOrder objects only allowed while testing")
+
+        cfg = api_cfg()
 
     def __repr__(self):
         return "MockOrder:{0}".format(self.__dict__)

--- a/api/domain/scene.py
+++ b/api/domain/scene.py
@@ -18,9 +18,38 @@ class Scene(object):
                 " sensor_type, job_name, retry_after, retry_limit, retry_count FROM"\
                 " ordering_scene WHERE "
 
-    def __init__(self, atts):
-        for key, value in atts.iteritems():
-            setattr(self, key, value)
+    def __init__(self, name=None, note=None, order_id=None, product_distro_location=None,
+                product_dload_url=None, cksum_distro_location=None, cksum_download_url=None,
+                status=None, processing_location=None, completion_date=None,
+                log_file_contents=None, ee_unit_id=None, tram_order_id=None,
+                sensor_type=None, job_name=None, retry_after=None, retry_limit=None,
+                retry_count=None):
+        self.name = name
+        self.note = note
+        self.order_id = order_id
+        self.product_distro_location = product_distro_location
+        self.product_dload_url= product_dload_url
+        self.cksum_distro_location = cksum_distro_location
+        self.cksum_download_url = cksum_download_url
+        self.status = status
+        self.processing_location = processing_location
+        self.completion_date = completion_date
+        self.log_file_contents = log_file_contents
+        self.ee_unit_id = ee_unit_id
+        self.tram_order_id = tram_order_id
+        self.sensor_type = sensor_type
+        self.job_name = job_name
+        self.retry_after = retry_after
+        self.retry_limit = retry_limit
+        self.retry_count = retry_count
+        with DBConnect(**cfg) as db:
+            sql = "select id from ordering_scene where "\
+                    "name = '{0}' and order_id = {1};".format(self.name, self.order_id)
+            db.select(sql)
+            if db:
+                self.id = db[0]['id']
+            else:
+                self.id = None
 
     def __repr__(self):
         return "Scene:{0}".format(self.__dict__)
@@ -74,7 +103,9 @@ class Scene(object):
             db.select(sql)
             returnlist = []
             for i in db:
-                obj = Scene(i)
+                sd = dict(i)
+                del sd["id"]
+                obj = Scene(**sd)
                 returnlist.append(obj)
 
         return returnlist

--- a/api/utils.py
+++ b/api/utils.py
@@ -16,7 +16,7 @@ def get_cfg(cfgfile=".cfgnfo"):
 
     :return: dict
     """
-    if cfgfile == ".cfgnfo":
+    if cfgfile == ".cfgnfo" or cfgfile == '.cfgnfo-test':
         cfg_path = os.path.join(os.path.expanduser('~'), '.cfgnfo')
     else:
         cfg_path = cfgfile
@@ -33,6 +33,13 @@ def get_cfg(cfgfile=".cfgnfo"):
     return cfg_info
 
 def api_cfg(cfgfile=".cfgnfo"):
+    try:
+        mode = os.environ["espa_api_testing"]
+        if mode == "True":
+            cfgfile = ".cfgnfo-test"
+    except:
+        pass
+
     config = get_cfg(cfgfile)['config']
     config['cursor_factory'] = psycopg2.extras.DictCursor
     return config

--- a/api/utils.py
+++ b/api/utils.py
@@ -17,7 +17,7 @@ def get_cfg(cfgfile=".cfgnfo"):
     :return: dict
     """
     if cfgfile == ".cfgnfo" or cfgfile == '.cfgnfo-test':
-        cfg_path = os.path.join(os.path.expanduser('~'), '.cfgnfo')
+        cfg_path = os.path.join(os.path.expanduser('~'), cfgfile)
     else:
         cfg_path = cfgfile
 

--- a/test/test_production_apiv0.py
+++ b/test/test_production_apiv0.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+import unittest
+import yaml
+import copy
+import re
+import os
+
+from api.ordering.version0 import API
+from api.utils import api_cfg, lowercase_all
+from api.dbconnect import DBConnect
+import version0_testorders as testorders
+from api.providers.validation import validation_schema
+from api.api_except import ValidationException
+import psycopg2.extras
+
+from api.domain.mock_order import MockOrder
+
+api = API()
+
+class TestProductionAPI(unittest.TestCase):
+    def setUp(self):
+        os.environ['espa_api_testing'] = 'True'
+        MockOrder.generate_testing_orders()
+
+    def tearDown(self):
+        os.environ['espa_api_testing'] = ''
+        MockOrder.tear_down_testing_orders()
+
+    def test_fetch_production_products_modis(self):
+        pass
+
+    def test_fetch_production_products_landsat(self):
+        pass
+
+    def test_fetch_production_products_plot(self):
+        pass
+
+    def test_update_product_details_update_status(self):
+        pass
+
+    def test_update_product_details_set_product_error(self):
+        pass
+
+    def test_update_product_details_set_product_unavailable(self):
+        pass
+
+    def test_update_product_details_mark_product_complete(self):
+        pass
+
+    def test_handle_orders_success(self):
+        pass
+
+    def test_handle_orders_fail(self):
+        pass
+
+    def queue_products_success(self):
+        pass
+
+    def queue_products_fail(self):
+        pass
+
+    def get_production_key(self):
+        pass
+
+
+
+
+
+
+
+
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This is what I've initially come up with as a solution for testing some of the SQL heavy production api methods. I'm not sure how else to sufficiently test those methods without hitting a database.

the setUp method in test_production_apiv0 sets an environment var, thats picked up by api_cfg, and looks for a .cfgnfo-test file in order to connect to  a test DB instance. The MockOrder class is then responsible for adding and removing test instances from the db.

@davidvhill @klsmith-usgs 