### PR TITLE
Check incoming EE scenes for auxiliary data availability

### DIFF
--- a/api/domain/sensor.py
+++ b/api/domain/sensor.py
@@ -6,6 +6,7 @@ Author: David V. Hill
 
 import re
 from api import ProductNotImplemented
+from api.util import julian_date_check
 import yaml
 
 # Grab details on product restrictions
@@ -232,23 +233,16 @@ class Landsat(SensorProduct):
         self.row = product_id[6:9].lstrip('0')
         self.year = product_id[9:13]
         self.doy = product_id[13:16]
+        self.julian = product_id[9:16]
         self.station = product_id[16:19]
         self.version = product_id[19:21]
 
     # SR based products are not available for those
     # dates where we are missing auxiliary data
     def sr_date_restricted(self):
-        if self.sensor_name:
-            # ['< 2016151 | > 2016164']
-            _rdstr = restricted[self.sensor_name]['by_date']['sr']
-            _yd = "".join([self.year, self.doy])
-            for rng in _rdstr:
-                _rds = rng.split("|")
-                if not eval(" ".join([_yd, _rds[0]])):
-                    # _yd is greater than lower bound
-                    if not eval(" ".join([_yd, _rds[1]])):
-                        # _yd is less than upper bound
-                        return True
+        if self.sensor_name in restricted:
+            if not julian_date_check(self.julian, restricted[self.sensor_name]['by_date']['sr']):
+                return True
         return False
 
 

--- a/api/domain/sensor.py
+++ b/api/domain/sensor.py
@@ -244,10 +244,12 @@ class Landsat(SensorProduct):
             _yd = "".join([self.year, self.doy])
             for rng in _rdstr:
                 _rds = rng.split("|")
-                if not eval(" ".join([_yd, _rds[0], 'and', _yd, _rds[1]])):
-                    return True
-        else:
-            return False
+                if not eval(" ".join([_yd, _rds[0]])):
+                    # _yd is greater than lower bound
+                    if not eval(" ".join([_yd, _rds[1]])):
+                        # _yd is less than upper bound
+                        return True
+        return False
 
 
 class LandsatTM(Landsat):

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -637,8 +637,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
             status = 'submitted'
             note = ''
             # All EE orders are for SR, require auxiliary data
-            _ps = sensor.instance(product.product_id)
-            if _ps.sr_date_restricted():
+            if product.sr_date_restricted():
                 status = 'unavailable'
                 note = 'auxiliary data unavailable for' \
                        'this scenes acquisition date'

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -15,6 +15,7 @@ import datetime
 import urllib
 import json
 import socket
+import yaml
 
 from cStringIO import StringIO
 
@@ -633,10 +634,20 @@ class ProductionProvider(ProductionProviderInterfaceV0):
             elif isinstance(product, sensor.Modis):
                 sensor_type = 'modis'
 
+            status = 'submitted'
+            note = ''
+            # All EE orders are for SR, require auxiliary data
+            _ps = sensor.instance(product.product_id)
+            if _ps.sr_date_restricted():
+                status = 'unavailable'
+                note = 'auxiliary data unavailable for' \
+                       'this scenes acquisition date'
+
             scene_dict = {'name': product.product_id,
                           'sensor_type': sensor_type,
                           'order_id': order_id,
-                          'status': 'submitted',
+                          'status': status,
+                          'note': note,
                           'ee_unit_id': s['unit_num']}
 
             bulk_ls.append(scene_dict)


### PR DESCRIPTION
Orders coming in via EE don't pass through our typical order validation process. Which means we were trying to process scenes to SR based products, for days where we didn't have the required auxiliary data.

This catches that. @klsmith-usgs 