### PR TITLE
Fixed invalid Landsat tile identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ Accepts requests for process from an HTTP POST with a JSON body.  The body is va
 ```json
 
 curl --user username:password -d '{"olitirs8": {
-                                                    "inputs": ["LC8027029201533LGN00"], 
+                                                    "inputs": ["LC80270292015233LGN00"], 
                                                     "products": ["sr"]
                                                  }, 
                                      "format": "gtiff", 


### PR DESCRIPTION
I'm learning how to use this new tool and was pretty confused when I hit a validation error when sending the exact order that's listed in the readme example!

```
{'message': {'1 validation errors:': ["Value u'lc8027029201533lgn00' for field "
                                      "'olitirs8.inputs[0]' does not match "
                                      'regular expression '
                                      "'^lc8\\d{3}\\d{3}\\d{4}\\d{3}\\w{3}.{2}$'"]},
 'status': 400}
```

And indeed, it's right, after the 2015 year tag, there should be 3 digits for the day of the year. I tried 033, 133, and finally a 233 in that position worked, and my order submitted successfully. 