### PR TITLE
include scene info/status for every ee order

### DIFF
--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -654,6 +654,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                 status = 'unavailable'
                 note = 'auxiliary data unavailable for' \
                        'this scenes acquisition date'
+                logger.info('check ee unavailable: {}'.format(product.__dict__))
 
             scene_dict = {'name': product.product_id,
                           'sensor_type': sensor_type,
@@ -661,6 +662,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                           'status': status,
                           'note': note,
                           'ee_unit_id': s['unit_num']}
+            logger.info('check ee processing: {}'.format(scene_dict))
 
             bulk_ls.append(scene_dict)
         return bulk_ls


### PR DESCRIPTION
Due to issues with scenes from EE which cannot be reproduced locally, this adds some new logging outputs, both for every single scene, as well as those which **should** be marked `unavailable`. 

For every single scene, a new line: 
```
2016-12-27 17:35:02,787 [INFO]: check ee processing: {'status': 'submitted', 'name': 'LE71940222016150NSG00', 'order_id': 717, 'note': '', 'sensor_type': 'landsat', 'ee_unit_id': 1} in ./api/providers/production/production_provider.py:665
```

When a scene is unavailable, a new line in the info.log file will include:

```
2016-12-27 17:35:02,787 [INFO]: check ee unavailable: {'sensor_code': 'LE7', 'product_id': 'LE71930232016159NSG00', 'julian': '2016159', 'station': 'NSG', 'doy': '159', 'version': '00', 'year': '2016', 'path': '193', 'shortname': 'etm7', 'row': '23'} in ./api/providers/production/production_provider.py:657
```
