### PR TITLE
LSRD 712 - Clean endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ curl --user username:password https://espa.cr.usgs.gov/api
 
 {
     "versions": {
-        "0": {
+        "v0": {
             "description": "First release of the ESPA API"
         }
     }
@@ -122,14 +122,14 @@ curl --user username:password https://espa.cr.usgs.gov/api/v0
                 "GET"
             ]
         },
-        "/api/v0/orders": {
+        "/api/v0/list-orders": {
             "function": "list orders for authenticated user",
             "methods": [
                 "HEAD",
                 "GET"
             ]
         },
-        "/api/v0/orders/<email>": {
+        "/api/v0/list-orders/<email>": {
             "function": "list orders for supplied email, for user collaboration",
             "methods": [
                 "HEAD",
@@ -152,6 +152,7 @@ curl --user username:password https://espa.cr.usgs.gov/api/v0
         }
     }
 }
+
 ```
 
 **GET /api/v0/user**<a id="apiUser"></a>

--- a/api/domain/__init__.py
+++ b/api/domain/__init__.py
@@ -74,13 +74,6 @@ user_api_operations = {
                     "GET"
                 ]
             },
-            "/api/v0/request/<ordernum>": {
-                'function': "retrieve order sent to server",
-                'methods': [
-                    "HEAD",
-                    "GET"
-                ]
-            },
             "/api/v0/order": {
                 'function': "point for accepting processing requests via HTTP POST with JSON body. Errors are returned to user, successful validation returns an orderid",
                 'methods': [
@@ -159,13 +152,6 @@ user_api_operations = {
             },
             "/api/v1/order/<ordernum>": {
                 'function': "retrieves a submitted order",
-                'methods': [
-                    "HEAD",
-                    "GET"
-                ]
-            },
-            "/api/v1/request/<ordernum>": {
-                'function': "retrieve order sent to server",
                 'methods': [
                     "HEAD",
                     "GET"

--- a/api/domain/__init__.py
+++ b/api/domain/__init__.py
@@ -53,14 +53,14 @@ user_api_operations = {
                     "GET"
                 ]
             },
-            "/api/v0/orders": {
+            "/api/v0/list-orders": {
                 'function': "list orders for authenticated user",
                 'methods': [
                     "HEAD",
                     "GET"
                 ]
             },
-            "/api/v0/orders/<email>": {
+            "/api/v0/list-orders/<email>": {
                 'function': "list orders for supplied email, for user collaboration",
                 'methods': [
                     "HEAD",
@@ -143,14 +143,14 @@ user_api_operations = {
                     "GET"
                 ]
             },
-            "/api/v1/orders": {
+            "/api/v1/list-orders": {
                 'function': "list orders for authenticated user",
                 'methods': [
                     "HEAD",
                     "GET"
                 ]
             },
-            "/api/v1/orders/<email>": {
+            "/api/v1/list-orders/<email>": {
                 'function': "list orders for supplied email, for user collaboration",
                 'methods': [
                     "HEAD",

--- a/api/interfaces/ordering/version1.py
+++ b/api/interfaces/ordering/version1.py
@@ -41,7 +41,8 @@ class API(object):
         """
         resp = dict()
         for version in user_api_operations:
-            resp[version] = user_api_operations[version]['description']
+            resp_ver = 'v{}'.format(version)
+            resp[resp_ver] = user_api_operations[version]['description']
         return resp
 
     def available_products(self, product_id, username):

--- a/api/transports/http.py
+++ b/api/transports/http.py
@@ -36,8 +36,8 @@ transport_api.add_resource(VersionInfo,
 
 transport_api.add_resource(AvailableProducts,
                            '/api/v<version>/available-products/<prod_id>',
-                           '/api/v<version>/available-products/',
-                           '/api/v<version>/available-products')
+                           '/api/v<version>/available-products',
+                           '/api/v<version>/available-products/')
 
 transport_api.add_resource(ValidationInfo,
                            '/api/v<version>/projections',

--- a/api/transports/http.py
+++ b/api/transports/http.py
@@ -36,6 +36,7 @@ transport_api.add_resource(VersionInfo,
 
 transport_api.add_resource(AvailableProducts,
                            '/api/v<version>/available-products/<prod_id>',
+                           '/api/v<version>/available-products/',
                            '/api/v<version>/available-products')
 
 transport_api.add_resource(ValidationInfo,

--- a/api/transports/http_user.py
+++ b/api/transports/http_user.py
@@ -147,8 +147,13 @@ class AvailableProducts(Resource):
         return espa.available_products(prod_list, auth.username())
 
     @staticmethod
-    def get(version, prod_id):
-        return espa.available_products(prod_id, auth.username())
+    def get(version, prod_id=None):
+        if prod_id:
+            return espa.available_products(prod_id, auth.username())
+        else:
+            response = {"status": 404, "message": ("Must supply a product id to {}/<prod_id>"
+                                                   .format(request.url.strip('/')))}
+            return response, response['status']
 
 
 class ListOrders(Resource):

--- a/test/test_flask_transport.py
+++ b/test/test_flask_transport.py
@@ -73,7 +73,7 @@ class TransportTestCase(unittest.TestCase):
     def test_get_api_response_content(self):
         response = self.app.get('/api', headers=self.headers, environ_base={'REMOTE_ADDR': '127.0.0.1'})
         resp_json = json.loads(response.get_data())
-        self.assertEqual(set(['1', '0']), set(resp_json.keys()))
+        self.assertEqual(set(['v1', 'v0']), set(resp_json.keys()))
 
     @patch('api.domain.user.User.get', MockUser.get)
     def test_get_api_info_response_content(self):


### PR DESCRIPTION
* Adds "v" to response from `api/` 
  * `{"v0": "Version 0 of the ESPA API", "v1": "Version 1 of the ESPA API"}`
* Handles GET `api/v0/available-products` more gracefully
* Updates `api/v0/` with 
  * list-orders as the correct endpoint for getting users orders
  * removed `/api/v0/request/<ordernum>`