### PR TITLE
LSRD 732 - Add human readable output

### DIFF
--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -272,8 +272,13 @@ class OrderValidatorV0(validictory.SchemaValidator):
                     date_restricted.pop(key, None)
 
             if date_restricted:
-                self._error('Requested products are restricted by date',
-                            date_restricted, fieldname, path=path)
+                if 'response-readable' in self.data_source:
+                    for product_type in date_restricted:
+                        self._errors.append("Requested {} products are restricted by date. Remove: {}"
+                                            .format(product_type, [x.upper() for x in date_restricted[product_type]]))
+                else:
+                    self._error('Requested products are restricted by date',
+                                date_restricted, fieldname, path=path)
 
         prods = []
         for key in avail_prods:

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -295,8 +295,13 @@ class OrderValidatorV0(validictory.SchemaValidator):
                     dif.remove(d)
 
         if dif:
-            self._error('Requested products are not available',
-                        dif, fieldname, path=path)
+            if 'response-readable' in self.data_source:
+                for d in dif:
+                    self._errors.append("Requested {} products are not available. Remove: {}"
+                                        .format(d, [s.upper() for s in x['inputs']]))
+            else:
+                self._error('Requested products are not available',
+                            dif, fieldname, path=path)
 
     def validate_oneormoreobjects(self, x, fieldname, schema, path, key_list):
         """Validates that at least one value is present from the list"""

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -292,11 +292,11 @@ class OrderValidatorV0(validictory.SchemaValidator):
             if date_restricted:
                 if 'response-readable' in self.data_source:
                     for product_type in date_restricted:
-                        msg = (r'See <a href="https://landsat.usgs.gov/landsat-surface-reflectance-high-'
-                               r'level-data-products">Caveats and Constraints</a> for more details. ')
-                        self._errors.append("Requested {} products are restricted by date. {}Remove {} scenes: {}"
-                                            .format(product_type, msg, path.split('.products')[0],
-                                                    [x.upper() for x in date_restricted[product_type]]))
+                        msg = (r'<br>See <a href="https://landsat.usgs.gov/landsat-surface-reflectance-high-'
+                               r'level-data-products">Caveats and Constraints</a> for more details.')
+                        self._errors.append("Requested {} products are restricted by date. Remove {} scenes: {} {}"
+                                            .format(product_type, path.split('.products')[0],
+                                                    [x.upper() for x in date_restricted[product_type]], msg))
                 else:
                     self._error('Requested products are restricted by date',
                                 date_restricted, fieldname, path=path)
@@ -318,8 +318,10 @@ class OrderValidatorV0(validictory.SchemaValidator):
         if dif:
             if 'response-readable' in self.data_source:
                 for d in dif:
-                    self._errors.append("Requested {} products are not available. Remove {} scenes: {}"
-                                        .format(d, path.split('.products')[0], [s.upper() for s in x['inputs']]))
+                    if type(x) == dict:
+                        scene_ids = [s.upper() for s in x['inputs']]
+                        self._errors.append("Requested {} products are not available. Remove {} scenes: {}"
+                                            .format(d, path.split('.products')[0], scene_ids))
             else:
                 self._error('Requested products are not available',
                             dif, fieldname, path=path)

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -292,8 +292,11 @@ class OrderValidatorV0(validictory.SchemaValidator):
             if date_restricted:
                 if 'response-readable' in self.data_source:
                     for product_type in date_restricted:
-                        self._errors.append("Requested {} products are restricted by date. Remove: {}"
-                                            .format(product_type, [x.upper() for x in date_restricted[product_type]]))
+                        msg = (r'See <a href="https://landsat.usgs.gov/landsat-surface-reflectance-high-'
+                               r'level-data-products">Caveats and Constraints</a> for more details. ')
+                        self._errors.append("Requested {} products are restricted by date. {}Remove {} scenes: {}"
+                                            .format(product_type, msg, path.split('.products')[0],
+                                                    [x.upper() for x in date_restricted[product_type]]))
                 else:
                     self._error('Requested products are restricted by date',
                                 date_restricted, fieldname, path=path)
@@ -315,8 +318,8 @@ class OrderValidatorV0(validictory.SchemaValidator):
         if dif:
             if 'response-readable' in self.data_source:
                 for d in dif:
-                    self._errors.append("Requested {} products are not available. Remove: {}"
-                                        .format(d, [s.upper() for s in x['inputs']]))
+                    self._errors.append("Requested {} products are not available. Remove {} scenes: {}"
+                                        .format(d, path.split('.products')[0], [s.upper() for s in x['inputs']]))
             else:
                 self._error('Requested products are not available',
                             dif, fieldname, path=path)

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -430,6 +430,7 @@ class BaseValidationSchema(object):
                                                 'properties': resize},
                                      'resampling_method': {'type': 'string',
                                                            'enum': resampling_methods},
+                                     'response-readable': {'type': 'boolean'},
                                      'plot_statistics': {'type': 'boolean'},
                                      'note': {'type': 'string',
                                               'required': False,

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -169,6 +169,24 @@ class OrderValidatorV0(validictory.SchemaValidator):
                     self._error(': field only accepts one object',
                                 len(value), fieldname, path=path)
 
+    def validate_enum(self, x, fieldname, schema, path, options=None):
+        '''
+        Validates that the value of the field is equal to one of the specified option values
+        '''
+        value = x.get(fieldname)
+        if value is not None:
+            if callable(options):
+                options = options(x)
+            if value not in options:
+                if not (value == '' and schema.get('blank', self.blank_by_default)):
+                    if 'response-readable' in self.data_source:
+                        self._errors.append("Not available: {} products for {} scenes. "
+                                            "Please choose from available products: {}"
+                                            .format(value, path.split('.products')[0], options))
+                    else:
+                        self._error("is not in the enumeration: {options!r}", value, fieldname,
+                                    options=options, path=path)
+
     def validate_enum_keys(self, x, fieldname, schema, path, valid_list):
         """Validates the keys in the given object match expected keys"""
         value = x.get(fieldname)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -220,6 +220,17 @@ class TestValidation(unittest.TestCase):
                                   '\nUsing test: {}'.format(exc_type, str(exc), test))
         #print c  # For initial debugging
 
+    def test_validate_allow_human_readable(self):
+        """
+        Assert that adding response-readable to the JSON request is accepted
+        """
+        valid_order = copy.deepcopy(self.base_order)
+        valid_order['response-readable'] = True
+        try:
+            good = api.validation.validate(valid_order, self.staffuser.username)
+        except ValidationException as e:
+            self.fail('Raised ValidationException: {}'.format(e.message))
+
 
 class TestInventory(unittest.TestCase):
     def setUp(self):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -59,7 +59,7 @@ class TestAPI(unittest.TestCase):
         os.environ['espa_api_testing'] = ''
 
     def test_api_versions_key_val(self):
-        self.assertEqual(set(api.api_versions().keys()), set(['0', '1']))
+        self.assertEqual(set(api.api_versions().keys()), set(['v0', 'v1']))
 
     def test_get_available_products_key_val(self):
         self.assertEqual(api.available_products(self.product_id, self.user.username).keys()[0], "tm5")

--- a/test/test_production_api.py
+++ b/test/test_production_api.py
@@ -64,7 +64,7 @@ class TestProductionAPI(unittest.TestCase):
         order_id = self.mock_order.generate_testing_order(self.user_id)
         self.mock_order.update_scenes(order_id, 'status', ['complete'])
         order = Order.find(order_id)
-        plot_scene = order.scenes()[0]
+        plot_scene = order.scenes({'name': 'plot'})[0]
         plot_scene.name = 'plot'
         plot_scene.sensor_type = 'plot'
         plot_scene.status = 'submitted'


### PR DESCRIPTION
* Allows `'response-readable'` in JSON request (primarily for espa-web)
* Outputs different validation messages if flag is present, otherwise behavior is unchanged