### PR TITLE
Hotfix - Unrecognized key 'response-readable'

### DIFF
--- a/api/domain/order.py
+++ b/api/domain/order.py
@@ -822,6 +822,7 @@ class OptionsConversion(object):
                 # No appropriate mapping as it is handled as a dummy
                 # scene in the DB
                 continue
+            # TODO: remove response-readable (should now be removed from order)
             elif key == 'note' or key == 'response-readable':
                 continue
             else:

--- a/api/domain/order.py
+++ b/api/domain/order.py
@@ -822,7 +822,7 @@ class OptionsConversion(object):
                 # No appropriate mapping as it is handled as a dummy
                 # scene in the DB
                 continue
-            elif key == 'note':
+            elif key == 'note' or key == 'response-readable':
                 continue
             else:
                 raise ValueError('Unrecognized key: {}'.format(key))

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -543,6 +543,8 @@ class ValidationProvider(ValidationInterfaceV0):
         if 'plot_statistics' in order and order['plot_statistics']:
             stats = True
 
+        _ = order.pop('response-readable', None)
+
         for key in order:
             if key in prod_keys:
                 item1 = order[key]['inputs'][0]

--- a/test/test_production_api.py
+++ b/test/test_production_api.py
@@ -524,7 +524,6 @@ class TestProductionAPI(unittest.TestCase):
                                          u'units': u'meters',
                                          u'west': -2415585.0},
                       u'note': u'CONUS_h1v1',
-                      u'response-readable': True,
 
                       u'projection': {u'aea': {u'central_meridian': -96,
                                                u'datum': u'nad83',

--- a/test/test_production_api.py
+++ b/test/test_production_api.py
@@ -524,6 +524,7 @@ class TestProductionAPI(unittest.TestCase):
                                          u'units': u'meters',
                                          u'west': -2415585.0},
                       u'note': u'CONUS_h1v1',
+                      u'response-readable': True,
 
                       u'projection': {u'aea': {u'central_meridian': -96,
                                                u'datum': u'nad83',


### PR DESCRIPTION
Allows new orders coming through the ODI web site to move into production (ignore the response-readable flag)