### PR TITLE
julian date must always be 3 characters

### DIFF
--- a/api/util/__init__.py
+++ b/api/util/__init__.py
@@ -120,7 +120,7 @@ def julian_from_date(year, month, day):
     '''Returns a string representation of a julian date for a given year, month, day'''
     dt = datetime.datetime.strptime('.'.join([year, month, day]), '%Y.%m.%d')
     tt = dt.timetuple()
-    return str(tt.tm_yday)
+    return str(tt.tm_yday).zfill(3)
 
 
 def chunkify(lst, n):


### PR DESCRIPTION
For a date like `LC08_L1TP_040033_20160224_20170224_01_T1`, this needs to convert to "2016055" julian doy. 

```python
>>> from api.util import julian_from_date
>>> julian_from_date('2016', '02', '24')
'055'
```
