### PR TITLE
Release Candidate 2017.06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Change Notes
 ###### June 2017 
-* **COMING SOON** Ability to cancel orders
+* Ability to cancel orders
 * Put all errors/warnings in "messages" JSON field
-* Remove CFMask product (replaced by pixel_qa **coming soon**)
+* Remove CFMask product (replaced by `pixel_qa`)
 * Bug fixes for API responses (HTTP Codes, Messages)
 * Add JSON filters to available-products, orders, and item-status
 * Remove `POST` http method from available-products 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -81,3 +81,7 @@ class InventoryException(Exception):
         self.response = {'Inputs Not Available': msg}
 
 
+class InventoryConnectionException(Exception):
+    """Exception handling if input data pool is down"""
+    def __init__(self, msg):
+        super(InventoryConnectionException, self).__init__(msg)

--- a/api/domain/restricted.yaml
+++ b/api/domain/restricted.yaml
@@ -4,7 +4,6 @@ all:
         - lst
         - swe
         - cloud
-        - pixel_qa
         - restricted_prod
     ordering:
         - olitirs8

--- a/api/domain/user.py
+++ b/api/domain/user.py
@@ -125,12 +125,12 @@ class User(object):
                       "last_login, date_joined, contactid) values " \
                       "(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) " \
                       "on conflict (username) " \
-                      "do update set (email, contactid) = (%s, %s) " \
+                      "do update set (email, contactid, last_login) = (%s, %s, %s) " \
                       "where auth_user.username = %s" \
                       "returning id"
         arg_tup = (username, email, first_name, last_name,
                    'pass', 'f', 't', 'f', nownow, nownow, contactid,
-                   email, contactid, username)
+                   email, contactid, nownow, username)
 
         with db_instance() as db:
             try:

--- a/api/external/lta.py
+++ b/api/external/lta.py
@@ -18,11 +18,6 @@ from api import util as utils
 
 config = ConfigurationProvider()
 
-if config.mode in ('dev', 'tst'):
-    import logging
-    logging.basicConfig(level=logging.INFO)
-    logging.getLogger('suds.client').setLevel(logging.DEBUG)
-
 
 def check_lta_available():
     """

--- a/api/external/mocks/lta.py
+++ b/api/external/mocks/lta.py
@@ -55,11 +55,11 @@ def get_available_orders():
         ]
     """
     ret = {}
-    ret[(123, 'klsmith@usgs.gov', 418781)] = [{'sceneid': 'LE70900652008327EDC00',
+    ret[('123', 'klsmith@usgs.gov', 418781)] = [{'sceneid': 'LE70900652008327EDC00',
                                                'unit_num': 789},
                                               {'sceneid': 'LE70900652008327EDC00',
                                                'unit_num': 780}]
-    ret[(124, 'klsmith@usgs.gov', 418781)] = [{'sceneid': 'LE70900652008327EDC00',
+    ret[('124', 'klsmith@usgs.gov', 418781)] = [{'sceneid': 'LE70900652008327EDC00',
                                                'unit_num': 780},
                                               {'sceneid': 'LE70900652008327EDC00',
                                                'unit_num': 799}]
@@ -69,10 +69,10 @@ def get_available_orders():
 def get_available_orders_partial(partial=False):
     ret = {}
     if partial:
-        ret[(125, 'klsmith@usgs.gov', 418781)] = [{'sceneid': 'LE70900652008327EDC00',
+        ret[('125', 'klsmith@usgs.gov', 418781)] = [{'sceneid': 'LE70900652008327EDC00',
                                                    'unit_num': 789}]
     else:
-        ret[(125, 'klsmith@usgs.gov', 418781)] = [{'sceneid': 'LE70900652008327EDC00',
+        ret[('125', 'klsmith@usgs.gov', 418781)] = [{'sceneid': 'LE70900652008327EDC00',
                                                    'unit_num': 789},
                                                   {'sceneid': 'LT50900652008327EDC00',
                                                    'unit_num': 780}]

--- a/api/interfaces/ordering/version1.py
+++ b/api/interfaces/ordering/version1.py
@@ -85,7 +85,7 @@ class API(object):
 
         return response
 
-    def fetch_user_orders(self, username='', email='', filters={}):
+    def fetch_user_orders(self, username='', email='', user_id='', filters={}):
         """ Return orders given a user id
 
         Args:
@@ -97,6 +97,7 @@ class API(object):
         try:
             response = self.ordering.fetch_user_orders(email=email,
                                                        username=username,
+                                                       user_id=user_id,
                                                        filters=filters)
         except:
             response = default_error_message

--- a/api/interfaces/ordering/version1.py
+++ b/api/interfaces/ordering/version1.py
@@ -148,9 +148,9 @@ class API(object):
             # capture the order
             response = self.ordering.place_order(order, user)
         except:
-            logger.debug("ERR version1 place_order arg: {2}: {0}\n"
-                         "exception {1}".format(order, traceback.format_exc(),
-                                                user.username))
+            logger.warning("ERR version1 place_order arg: {2}: {0}\n"
+                           "exception {1}".format(order, traceback.format_exc(),
+                                                  user.username))
             raise
 
         return response

--- a/api/interfaces/production/version1.py
+++ b/api/interfaces/production/version1.py
@@ -83,17 +83,17 @@ class API(object):
 
         return response
 
-    def handle_orders(self):
+    def handle_orders(self, params):
         """Handler for accepting orders and products into the processing system
 
         Args:
-            none
+            params (dict): args for the action. valid keys: username
 
         Returns:
             True if successful
         """
         try:
-            response = self.production.handle_orders()
+            response = self.production.handle_orders(**params)
         except:
             logger.debug("ERR version1 handle_orders. trace: {0}".format(traceback.format_exc()))
             response = default_error_message

--- a/api/notification/emails.py
+++ b/api/notification/emails.py
@@ -86,11 +86,9 @@ class Emails(object):
                            subject=subject,
                            body=email_msg)
 
-    def send_all_initial(self):
+    def send_all_initial(self, orders):
         '''Finds all the orders that have not had their initial emails sent and
         sends them'''
-
-        orders = Order.where({'status': 'ordered', 'initial_email_sent IS': None})
         for o in orders:
             if not o.initial_email_sent:
                 self.send_initial(o.orderid)

--- a/api/providers/inventory/inventory_provider.py
+++ b/api/providers/inventory/inventory_provider.py
@@ -1,7 +1,7 @@
 from api.providers.inventory import InventoryInterfaceV0
 
 from api.external import lta, lpdaac
-from api import InventoryException
+from api import InventoryException, InventoryConnectionException
 from api.domain import sensor
 
 
@@ -30,8 +30,14 @@ class InventoryProviderV0(InventoryInterfaceV0):
                 lpdaac_ls.extend(order[key]['inputs'])
 
         if lta_ls:
+            if not lta.check_lta_available():
+                msg = 'Could not connect to LTA data source'
+                raise InventoryConnectionException(msg)
             results.update(self.check_LTA(lta_ls))
         if lpdaac_ls:
+            if not lpdaac.check_lpdaac_available():
+                msg = 'Could not connect to LPDAAC data source'
+                raise InventoryConnectionException(msg)
             results.update(self.check_LPDAAC(lpdaac_ls))
 
         not_avail = []

--- a/api/providers/ordering/ordering_provider.py
+++ b/api/providers/ordering/ordering_provider.py
@@ -189,8 +189,7 @@ class OrderingProvider(ProviderInterfaceV0):
 
         logger.info('Received request to cancel {} from {}'
                     .format(orderid, request_ip_address))
-        # TODO: ADD "queued" to list, when proc can handle exception
-        killable_scene_states = ('submitted', 'oncache', 'onorder',
+        killable_scene_states = ('submitted', 'oncache', 'onorder', 'queued',
                                  'error', 'unavailable', 'complete')
         scenes = order.scenes(sql_dict={'status': killable_scene_states})
         if len(scenes) > 0:

--- a/api/providers/ordering/ordering_provider.py
+++ b/api/providers/ordering/ordering_provider.py
@@ -122,15 +122,19 @@ class OrderingProvider(ProviderInterfaceV0):
 
         return pub_prods
 
-    def fetch_user_orders(self, username='', email='', filters=None):
+    def fetch_user_orders(self, username='', email='', user_id='', filters=None):
 
         if filters and not isinstance(filters, dict):
             raise OrderingProviderException('filters must be dict')
 
         if username:
-            user = User.where({'username': username})
+            usearch = {'username': username}
         elif email:
-            user = User.where({'email': email})
+            usearch = {'email': email}
+        elif user_id:
+            usearch = {'id': user_id}
+
+        user = User.where(usearch)
         if len(user) != 1:
             return list()
         else:

--- a/api/providers/production/__init__.py
+++ b/api/providers/production/__init__.py
@@ -108,11 +108,6 @@ class ProductionProviderInterfaceV0(object):
         return
 
     @abc.abstractmethod
-    def handle_submitted_products(self):
-        ''' handles all submitted products in the system '''
-        return
-
-    @abc.abstractmethod
     def send_completion_email(order):
         ''' public interface to send the completion email '''
         return

--- a/api/providers/production/mocks/production_provider.py
+++ b/api/providers/production/mocks/production_provider.py
@@ -22,7 +22,7 @@ class MockProductionProvider(object):
     def respond_true(self, *args, **kwargs):
         return True
 
-    def contact_ids_list(self):
+    def contact_ids_list(self, scenes=None):
         users = User.where({'id >': 0})
         return [u.contactid for u in users]
 

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -903,7 +903,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
             #look to see if they are ee orders.  If true then update the
             #unit status
             invalid = [p for p in product_list if p.name in results['invalid']]
-            self.set_products_unavailable(invalid, 'Not found in landsat archive')
+            self.set_products_unavailable(invalid, 'No longer found in the archive, please search again')
 
         return True
 

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -113,7 +113,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                 logger.debug('ERR file was not found: {}'
                              .format(completed_file_location))
             Scene.bulk_update([scene.id], Scene.cancel_opts())
-            return True  # TODO: proc False?
+            return False
 
         scene.status = 'complete'
         scene.processing_location = processing_loc
@@ -241,7 +241,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         scene = Scene.by_name_orderid(name, order.id)
         if order.status == 'cancelled':
             Scene.bulk_update([scene.id], Scene.cancel_opts())
-            return True  # TODO: proc False?
+            return False
         if processing_loc:
             scene.processing_location = processing_loc
         if status:

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -584,7 +584,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                                 .format(item['orderid'], item['name']))
         return results
 
-    def load_ee_orders(self):
+    def load_ee_orders(self, contact_id=None):
         """
         Loads all the available orders from lta into
         our database and updates their status
@@ -597,6 +597,9 @@ class ProductionProvider(ProductionProviderInterfaceV0):
             return
 
         orders = lta.get_available_orders()
+        if contact_id:
+            orders = [(o, e, c) for (o, e, c) in orders if c == contact_id]
+        logger.info('# Orders available from EE: {}'.format(len(orders)))
 
         # {(order_num, email, contactid): [{sceneid: ,
         #                                   unit_num:}]}
@@ -769,14 +772,12 @@ class ProductionProvider(ProductionProviderInterfaceV0):
 
             self.load_ee_scenes(missing_scenes, order_id, missed=True)
 
-    def handle_retry_products(self):
+    def handle_retry_products(self, products):
         """
         Handle all products in retry status
         :return: True
         """
         try:
-            now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
-            products = Scene.where({'status': 'retry', 'retry_after <': now})
             if len(products) > 0:
                 Scene.bulk_update([p.id for p in products], {'status': 'submitted', 'note': ''})
         except Exception as e:
@@ -785,12 +786,10 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         return True
 
     @staticmethod
-    def handle_cancelled_orders():
+    def handle_cancelled_orders(orders):
         """ Find all orders without cancelled order email sent, and sends them
         :return: True
         """
-        orders = Order.where({'status': 'cancelled',
-                              'completion_email_sent IS': None})
         for order in orders:
             if not order.completion_email_sent:
                 if onlinecache.exists(order.orderid):
@@ -800,13 +799,11 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                     order.update('completion_email_sent', datetime.datetime.now())
         return True
 
-    def handle_onorder_landsat_products(self):
+    def handle_onorder_landsat_products(self, products):
         """
         Handles landsat products still on order
         :return: True
         """
-        products = Scene.where({'status': 'onorder', 'tram_order_id IS NOT': None})
-
         # lets control how many scenes were going to ping LTA for status updates
         # every 7 (currently) minutes
         # tram_order_id is sequential (looks like a timestamp), so we can sort
@@ -852,23 +849,20 @@ class ProductionProvider(ProductionProviderInterfaceV0):
 
         return True
 
-    def send_initial_emails(self):
+    def send_initial_emails(self, orders):
         """
         ProductionProvider wrapper for Emails.send_all_initial
         :return: True
         """
-        return emails.Emails().send_all_initial()
+        return emails.Emails().send_all_initial(orders)
 
     @staticmethod
-    def get_contactids_for_submitted_landsat_products():
+    def get_contactids_for_submitted_landsat_products(scenes):
         """
         Assembles a list of contactids for submitted landsat products
         :return: list
         """
         logger.info("Retrieving contact ids for submitted landsat products")
-        scenes = Scene.where({'status': 'submitted',
-                              'sensor_type': 'landsat'})
-
         if scenes:
             user_ids = [s.order_attr('user_id') for s in scenes]
             users = User.where({'id': tuple(user_ids)})
@@ -886,7 +880,8 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         """
         logger.info("Updating landsat product status")
         user = User.by_contactid(contact_id)
-        product_list = Order.get_user_scenes(user.id, {'sensor_type': 'landsat','status': 'submitted'})[:500]
+        product_list = Order.get_user_scenes(user.id, {'sensor_type': 'landsat','status': 'submitted'})
+        product_list = sorted(product_list, key=lambda x: x.id)[:500]
         logger.info("Ordering {0} scenes for contact:{1}".format(len(product_list), contact_id))
 
         product_list = self.check_dependencies_for_products(product_list)
@@ -912,7 +907,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
 
         return True
 
-    def mark_nlaps_unavailable(self):
+    def mark_nlaps_unavailable(self, landsat_products):
         """
         Inner function to support marking nlaps products unavailable
         :return: True
@@ -920,7 +915,6 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         logger.info("Looking for submitted landsat products, In mark_nlaps_unavailable")
 
         # First things first... filter out all the nlaps scenes
-        landsat_products = Scene.where({'status': 'submitted', 'sensor_type': 'landsat'})
         landsat_submitted = [l.name for l in landsat_products]
         logger.info("Found {0} submitted landsat products".format(len(landsat_submitted)))
 
@@ -962,7 +956,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                 passed_dep_check.append(s)
         return passed_dep_check
 
-    def handle_submitted_landsat_products(self):
+    def handle_submitted_landsat_products(self, scenes):
         """
         Handles all submitted landsat products
         :return: True
@@ -972,9 +966,8 @@ class ProductionProvider(ProductionProviderInterfaceV0):
             return False
         logger.info('Handling submitted landsat products...')
         # Here's the real logic for this handling submitted landsat products
-        self.mark_nlaps_unavailable()
 
-        contactids = self.get_contactids_for_submitted_landsat_products()
+        contactids = self.get_contactids_for_submitted_landsat_products(scenes)
 
         for contact_id in contactids:
             if contact_id:
@@ -990,7 +983,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
 
         return True
 
-    def handle_submitted_modis_products(self):
+    def handle_submitted_modis_products(self, modis_products):
         """
         Moves all submitted modis products to oncache if true
         :return: True
@@ -999,7 +992,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
             logger.debug('DAAC down. Skip handle_submitted_modis_products...')
             return False
         logger.info("Handling submitted modis products...")
-        modis_products = Scene.where({'status': 'submitted', 'sensor_type': 'modis'})
+
         logger.warn("Found {0} submitted modis products".format(len(modis_products)))
 
         if len(modis_products) > 0:
@@ -1021,14 +1014,14 @@ class ProductionProvider(ProductionProviderInterfaceV0):
 
         return True
 
-    def handle_submitted_plot_products(self):
+    def handle_submitted_plot_products(self, plot_scenes):
         """
         Moves plot products from submitted to oncache status once all their underlying rasters are complete
         or unavailable
         :return: True
         """
         logger.info("Handling submitted plot products...")
-        plot_scenes = Scene.where({'status': 'submitted', 'sensor_type': 'plot'})
+
         plot_orders = [Order.find(s.order_id) for s in plot_scenes]
         logger.info("Found {0} submitted plot orders".format(len(plot_orders)))
 
@@ -1060,17 +1053,6 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                 else:
                     logger.debug('{}'.format(plots_in_order))
                     raise ValueError('Too many ({n}) plots in order {oid}'.format(n=len(plots_in_order), oid=order.id))
-        return True
-
-    def handle_submitted_products(self):
-        """
-        Handles all submitted products in the system
-        :return: True
-        """
-        logger.info('Handling submitted products...')
-        self.handle_submitted_landsat_products()
-        self.handle_submitted_modis_products()
-        self.handle_submitted_plot_products()
         return True
 
     def send_completion_email(self, order):
@@ -1119,13 +1101,12 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                     raise e
         return True
 
-    def calc_scene_download_sizes(self):
+    def calc_scene_download_sizes(self, scenes):
         """
         Processing occasionally reports product completion before we're able to
         see the download and retrieve its size
         :return: True
         """
-        scenes = Scene.where({'status': 'complete', 'download_size': 0})
         for scene in scenes:
             if os.path.exists(scene.product_distro_location):
                 scene.update('download_size', os.path.getsize(scene.product_distro_location))
@@ -1138,13 +1119,12 @@ class ProductionProvider(ProductionProviderInterfaceV0):
 
         return True
 
-    def finalize_orders(self):
+    def finalize_orders(self, orders):
         """
         Checks all open orders in the system and marks them complete if all
         required scene processing is done
         :return: True
         """
-        orders = Order.where({'status': 'ordered'})
         [self.update_order_if_complete(o) for o in orders]
         return True
 
@@ -1198,8 +1178,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         return True
 
     @staticmethod
-    def handle_failed_ee_updates():
-        scenes = Scene.where({'failed_lta_status_update IS NOT': None})
+    def handle_failed_ee_updates(scenes):
         n_failed = len(scenes)
         if n_failed:
             logger.debug('Failed LTA status count: {} scenes'.format(n_failed))
@@ -1217,20 +1196,60 @@ class ProductionProvider(ProductionProviderInterfaceV0):
                             'scene {}\n{}'.format(s.id, e))
         return True
 
-    def handle_orders(self):
+    def handle_orders(self, username=None):
         """
         Logic handler for how we accept orders + products into the system
         :return: True
         """
-        self.send_initial_emails()
-        self.handle_onorder_landsat_products()
-        self.handle_retry_products()
-        self.load_ee_orders()
-        self.handle_failed_ee_updates()
-        self.handle_cancelled_orders()
-        self.handle_submitted_products()
-        self.calc_scene_download_sizes()
-        self.finalize_orders()
+        filters = {'status': 'ordered'}
+        user = None
+        if username:
+            user = User.by_username(username)
+            logger.warn('@USER {} ({})'.format(user.username, user.email))
+            filters.update(user_id=user.id)
+        pending_orders = [o.id for o in Order.where(filters)]
+        if len(pending_orders) < 1:
+            logger.error('No pending orders found: {}'.format(filters))
+            return False
+        logger.info('# Pending orders to handle: {}'.format(len(pending_orders)))
+
+        orders = Order.where({'id': pending_orders, 'initial_email_sent IS': None})
+        self.send_initial_emails(orders)
+
+        products = Scene.where({'status': 'onorder', 'tram_order_id IS NOT': None, 'order_id': pending_orders})
+        self.handle_onorder_landsat_products(products)
+
+        now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
+        products = Scene.where({'status': 'retry', 'retry_after <': now, 'order_id': pending_orders})
+        self.handle_retry_products(products)
+
+        contactid = user.contactid if user else None
+        self.load_ee_orders(contactid)
+
+        scenes = Scene.where({'failed_lta_status_update IS NOT': None, 'order_id': pending_orders})
+        self.handle_failed_ee_updates(scenes)
+
+        orders = Order.where({'status': 'cancelled',
+                              'completion_email_sent IS': None, 'id': pending_orders})
+        self.handle_cancelled_orders(orders)
+
+        scenes = Scene.where({'status': 'submitted', 'sensor_type': 'landsat', 'order_id': pending_orders})
+        self.mark_nlaps_unavailable(scenes)
+
+        scenes = Scene.where({'status': 'submitted', 'sensor_type': 'landsat', 'order_id': pending_orders})
+        self.handle_submitted_landsat_products(scenes)
+
+        scenes = Scene.where({'status': 'submitted', 'sensor_type': 'modis', 'order_id': pending_orders})
+        self.handle_submitted_modis_products(scenes)
+
+        scenes = Scene.where({'status': 'submitted', 'sensor_type': 'plot', 'order_id': pending_orders})
+        self.handle_submitted_plot_products(scenes)
+
+        scenes = Scene.where({'status': 'complete', 'download_size': 0, 'order_id': pending_orders})
+        self.calc_scene_download_sizes(scenes)
+
+        orders = Order.where({'status': 'ordered', 'id': pending_orders})
+        self.finalize_orders(orders)
 
         cache_key = 'orders_last_purged'
         result = cache.get(cache_key)

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -103,19 +103,6 @@ class OrderValidatorV0(validictory.SchemaValidator):
                 return
             if not self.validate_type_string(self.data_source['image_extents']['units']):
                 return
-            # Validate UTM zone matches image_extents
-            if self.validate_type_object(self.data_source['projection'].get('utm')):
-                if not self.validate_type_integer(self.data_source['projection']['utm'].get('zone')):
-                    return
-                cdict = dict(inzone=self.data_source['projection']['utm']['zone'],
-                             east=self.data_source['image_extents']['east'],
-                             west=self.data_source['image_extents']['west'],
-                             zbuffer=3)
-                if not self.is_utm_zone_nearby(**cdict):
-                    msg = ('image_extents ({east}E,{west}W) are not near the'
-                           ' requested UTM zone ({inzone})'
-                           .format(**cdict))
-                    self._errors.append(msg)
 
             calc_args['xmax'] = self.data_source['image_extents']['east']
             calc_args['ymax'] = self.data_source['image_extents']['north']
@@ -158,6 +145,21 @@ class OrderValidatorV0(validictory.SchemaValidator):
             msg = ('{}:{} pixel count value falls below acceptable threshold'
                    ' of 1 pixel'.format(path, fieldname, cmin))
             self._errors.append(msg)
+
+        if 'image_extents' in self.data_source:
+            # Validate UTM zone matches image_extents
+            if self.validate_type_object(self.data_source['projection'].get('utm')):
+                if not self.validate_type_integer(self.data_source['projection']['utm'].get('zone')):
+                    return
+                cdict = dict(inzone=self.data_source['projection']['utm']['zone'],
+                             east=self.data_source['image_extents']['east'],
+                             west=self.data_source['image_extents']['west'],
+                             zbuffer=3)
+                if not self.is_utm_zone_nearby(**cdict):
+                    msg = ('image_extents ({east}E,{west}W) are not near the'
+                           ' requested UTM zone ({inzone})'
+                           .format(**cdict))
+                    self._errors.append(msg)
 
     @staticmethod
     def is_utm_zone_nearby(inzone, east, west, zbuffer=3):

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -146,28 +146,28 @@ class OrderValidatorV0(validictory.SchemaValidator):
                    ' of 1 pixel'.format(path, fieldname, cmin))
             self._errors.append(msg)
 
-        if 'image_extents' in self.data_source:
-            # Validate UTM zone matches image_extents
-            if self.validate_type_object(self.data_source['projection'].get('utm')):
-                if not self.validate_type_integer(self.data_source['projection']['utm'].get('zone')):
-                    return
-                if not self.data_source['image_extents']['units'] == 'dd':
-                    return
-                cdict = dict(inzone=self.data_source['projection']['utm']['zone'],
-                             east=self.data_source['image_extents']['east'],
-                             west=self.data_source['image_extents']['west'],
-                             zbuffer=3)
-                if not self.is_utm_zone_nearby(**cdict):
-                    msg = ('image_extents ({east}E,{west}W) are not near the'
-                           ' requested UTM zone ({inzone})'
-                           .format(**cdict))
-                    self._errors.append(msg)
-
-    @staticmethod
-    def is_utm_zone_nearby(inzone, east, west, zbuffer=3):
-        def long2utm(dd_lon):
-            return (math.floor((dd_lon + 180) / 6.) % 60) + 1
-        return (long2utm(west) - zbuffer) <= inzone <= (long2utm(east) + zbuffer)
+    #     if 'image_extents' in self.data_source:
+    #         # Validate UTM zone matches image_extents
+    #         if self.validate_type_object(self.data_source['projection'].get('utm')):
+    #             if not self.validate_type_integer(self.data_source['projection']['utm'].get('zone')):
+    #                 return
+    #             if not self.data_source['image_extents']['units'] == 'dd':
+    #                 return
+    #             cdict = dict(inzone=self.data_source['projection']['utm']['zone'],
+    #                          east=self.data_source['image_extents']['east'],
+    #                          west=self.data_source['image_extents']['west'],
+    #                          zbuffer=3)
+    #             if not self.is_utm_zone_nearby(**cdict):
+    #                 msg = ('image_extents ({east}E,{west}W) are not near the'
+    #                        ' requested UTM zone ({inzone})'
+    #                        .format(**cdict))
+    #                 self._errors.append(msg)
+    #
+    # @staticmethod
+    # def is_utm_zone_nearby(inzone, east, west, zbuffer=3):
+    #     def long2utm(dd_lon):
+    #         return (math.floor((dd_lon + 180) / 6.) % 60) + 1
+    #     return (long2utm(west) - zbuffer) <= inzone <= (long2utm(east) + zbuffer)
 
     @staticmethod
     def calc_extent(xmax, ymax, xmin, ymin, extent_units, resize_units, resize_pixel):

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -105,6 +105,8 @@ class OrderValidatorV0(validictory.SchemaValidator):
                 return
             # Validate UTM zone matches image_extents
             if self.validate_type_object(self.data_source['projection'].get('utm')):
+                if not self.validate_type_integer(self.data_source['projection']['utm'].get('zone')):
+                    return
                 cdict = dict(inzone=self.data_source['projection']['utm']['zone'],
                              east=self.data_source['image_extents']['east'],
                              west=self.data_source['image_extents']['west'],

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -151,6 +151,8 @@ class OrderValidatorV0(validictory.SchemaValidator):
             if self.validate_type_object(self.data_source['projection'].get('utm')):
                 if not self.validate_type_integer(self.data_source['projection']['utm'].get('zone')):
                     return
+                if not self.data_source['image_extents']['units'] == 'dd':
+                    return
                 cdict = dict(inzone=self.data_source['projection']['utm']['zone'],
                              east=self.data_source['image_extents']['east'],
                              west=self.data_source['image_extents']['west'],

--- a/api/system/logger.py
+++ b/api/system/logger.py
@@ -9,6 +9,13 @@ from api.providers.configuration.configuration_provider import ConfigurationProv
 
 config = ConfigurationProvider()
 
+if config.mode not in ('tst', 'dev'):
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("passlib.registry").setLevel(logging.WARNING)
+else:
+    logging.getLogger('suds.client').setLevel(logging.DEBUG)
+    logging.getLogger("requests").setLevel(logging.DEBUG)
+
 LOG_FORMAT = ("%(asctime)s [%(levelname)s]: %(message)s in %(pathname)s:%(lineno)d")
 
 class DbgFilter(Filter):

--- a/api/transports/http_production.py
+++ b/api/transports/http_production.py
@@ -83,7 +83,8 @@ class ProductionOperations(Resource):
             params = request.args.to_dict(flat=True)
             resp = espa.fetch_production_products(params)
         elif 'handle-orders' in request.url:
-            resp = espa.handle_orders()
+            params = request.get_json(force=True)
+            resp = espa.handle_orders(params)
 
         return prep_response(resp)
 

--- a/api/transports/http_production.py
+++ b/api/transports/http_production.py
@@ -83,7 +83,7 @@ class ProductionOperations(Resource):
             params = request.args.to_dict(flat=True)
             resp = espa.fetch_production_products(params)
         elif 'handle-orders' in request.url:
-            params = request.get_json(force=True)
+            params = request.get_json(force=True, silent=True) or {}
             resp = espa.handle_orders(params)
 
         return prep_response(resp)

--- a/api/transports/http_user.py
+++ b/api/transports/http_user.py
@@ -243,16 +243,17 @@ class ListOrders(Resource):
         filters = request.get_json(force=True, silent=True)
         search = dict(username=auth.username(), filters=filters)
         if email:  # Allow user collaboration
-            user = User.where({'email': email})
+            for usearch in ('email', 'username'):
+                user = User.where({usearch: email})
+                if len(user):
+                    break
             if not len(user):
-                user = User.where({'username': email})
-            if len(user) == 1:
-                search = dict(email=str(email), filters=filters)
-            else:
-                response = MessagesResponse(warnings=["User {} not found"
+                response = MessagesResponse(warnings=["Username/email {} not found"
                                                       .format(email)],
                                             code=200)
                 return response()
+            else:
+                search = {'filters': filters, usearch: email}
 
         response = OrdersResponse(espa.fetch_user_orders(**search))
         response.limit = ('orderid',)

--- a/api/transports/http_user.py
+++ b/api/transports/http_user.py
@@ -368,10 +368,6 @@ class Ordering(Resource):
             return message()
         else:
             orderid, status = body.get('orderid'), body.get('status')
-        if not user.is_staff():  # TODO: plan to be public facing
-            msg = ('Order cancellation is not available yet')
-            message = MessagesResponse(errors=[msg], code=400)
-            return message()
         orders = espa.fetch_order(orderid)
         if orders[0].user_id != user.id and not user.is_staff():
             msg = ('User {} is not allowed to cancel order {}'

--- a/api/transports/http_user.py
+++ b/api/transports/http_user.py
@@ -412,7 +412,7 @@ class ItemStatus(Resource):
     def get(version, orderid=None, itemnum='ALL'):
         user = flask.g.user
         filters = request.get_json(force=True, silent=True)
-        if not isinstance(filters, dict):
+        if filters and not isinstance(filters, dict):
             message = MessagesResponse(errors=['Invalid filters supplied'],
                                        code=400)
             return message()

--- a/api/transports/http_user.py
+++ b/api/transports/http_user.py
@@ -172,11 +172,11 @@ class Index(Resource):
         return 'Welcome to the ESPA API, please direct requests to /api'
 
     @staticmethod
-    def post(version):
+    def post():
         return BadMethodResponse()
 
     @staticmethod
-    def put(version):
+    def put():
         return BadMethodResponse()
 
 
@@ -227,11 +227,11 @@ class AvailableProducts(Resource):
         return espa.available_products(prod_list, auth.username())
 
     @staticmethod
-    def post(version):
+    def post(version, prod_id=None):
         return BadMethodResponse()
 
     @staticmethod
-    def put(version):
+    def put(version, prod_id=None):
         return BadMethodResponse()
 
 
@@ -260,11 +260,11 @@ class ListOrders(Resource):
         return response()
 
     @staticmethod
-    def post(version):
+    def post(version, email=None):
         return BadMethodResponse()
 
     @staticmethod
-    def put(version):
+    def put(version, email=None):
         return BadMethodResponse()
 
 
@@ -323,7 +323,7 @@ class Ordering(Resource):
         return response()
 
     @staticmethod
-    def post(version):
+    def post(version, ordernum=None):
         user = flask.g.user
         message = None
         order = request.get_json(force=True, silent=True)
@@ -353,7 +353,7 @@ class Ordering(Resource):
             return message()
 
     @staticmethod
-    def put(version):
+    def put(version, ordernum=None):
         user = flask.g.user
         remote_addr = user_ip_address()
 
@@ -425,11 +425,11 @@ class ItemStatus(Resource):
         return message()
 
     @staticmethod
-    def post(version):
+    def post(version, orderid=None, itemnum=None):
         return BadMethodResponse()
 
     @staticmethod
-    def put(version):
+    def put(version, orderid=None, itemnum=None):
         return BadMethodResponse()
 
 

--- a/api/transports/http_user.py
+++ b/api/transports/http_user.py
@@ -416,6 +416,10 @@ class ItemStatus(Resource):
     def get(version, orderid=None, itemnum='ALL'):
         user = flask.g.user
         filters = request.get_json(force=True, silent=True)
+        if not isinstance(filters, dict):
+            message = MessagesResponse(errors=['Invalid filters supplied'],
+                                       code=400)
+            return message()
         item_status = espa.item_status(orderid, itemnum, user.username,
                                 filters=filters)
         message = ItemsResponse(item_status, code=200)

--- a/docs/API-RESOURCES-LIST.md
+++ b/docs/API-RESOURCES-LIST.md
@@ -427,8 +427,6 @@ curl --user <erosusername>:<erospassword> -d '{"olitirs8_collection": {
 ```
 <a id="apiUpdateOrder"></a>**PUT /api/v0/order**
 
-**COMING SOON**
-
 Update an order with a JSON body. 
 
 ```bash

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -779,9 +779,7 @@
     "### PLEASE BE CAREFUL!\n",
     "\n",
     "ESPA processes your orders in the sequence in which they are recieved.  \n",
-    "You may want to remove blocking orders in your queue, to prioritize your latest orders\n",
-    "\n",
-    "**COMING SOON**"
+    "You may want to remove blocking orders in your queue, to prioritize your latest orders"
    ]
   },
   {

--- a/examples/api_demo.py
+++ b/examples/api_demo.py
@@ -279,8 +279,6 @@ print(json.dumps(resp, indent=4))
 # 
 # ESPA processes your orders in the sequence in which they are recieved.  
 # You may want to remove blocking orders in your queue, to prioritize your latest orders
-# 
-# **COMING SOON**
 
 # In[27]:
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -238,6 +238,13 @@ class TestValidation(unittest.TestCase):
                 with self.assertRaisesRegexp(exc_type, err_message):
                     api.validation.validate(invalid_order, self.staffuser.username)
 
+    def test_validate_utm_zone(self):
+        invalid_order = copy.deepcopy(self.base_order)
+        invalid_order['projection'] = {'utm': {'zone': 50, 'zone_ns': 'north'}}
+        invalid_order['image_extents'] = {'east': 32.5, 'north': 114.9, 'south': 113.5, 'units': u'dd', 'west': 31.5}
+        with self.assertRaisesRegexp(ValidationException, 'are not near the requested UTM zone'):
+            api.validation.validate(invalid_order, self.staffuser.username)
+
 
 class TestInventory(unittest.TestCase):
     def setUp(self):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -238,12 +238,12 @@ class TestValidation(unittest.TestCase):
                 with self.assertRaisesRegexp(exc_type, err_message):
                     api.validation.validate(invalid_order, self.staffuser.username)
 
-    def test_validate_utm_zone(self):
-        invalid_order = copy.deepcopy(self.base_order)
-        invalid_order['projection'] = {'utm': {'zone': 50, 'zone_ns': 'north'}}
-        invalid_order['image_extents'] = {'east': 32.5, 'north': 114.9, 'south': 113.5, 'units': u'dd', 'west': 31.5}
-        with self.assertRaisesRegexp(ValidationException, 'are not near the requested UTM zone'):
-            api.validation.validate(invalid_order, self.staffuser.username)
+    # def test_validate_utm_zone(self):
+    #     invalid_order = copy.deepcopy(self.base_order)
+    #     invalid_order['projection'] = {'utm': {'zone': 50, 'zone_ns': 'north'}}
+    #     invalid_order['image_extents'] = {'east': 32.5, 'north': 114.9, 'south': 113.5, 'units': u'dd', 'west': 31.5}
+    #     with self.assertRaisesRegexp(ValidationException, 'are not near the requested UTM zone'):
+    #         api.validation.validate(invalid_order, self.staffuser.username)
 
 
 class TestInventory(unittest.TestCase):


### PR DESCRIPTION
## Status
**Ready for internal system test June 22**

## Description
* Enable cancel orders (now includes "queued" scenes)
* Ordering Pixel_QA stand-alone product
* Change inventory misses to note "No longer found in archive"
* User-specific order disposition
* ~~Restrict UTM Zone to match (+/- 3 zone) requested image-extents~~
* Raise InventoryConnectionException to produce warning messages
* Bug fixes: 
    * list-orders: invalid username lookup
	* User class: update last_login upon lookup 
	* HTTP Methods: raise BadMethodResponse on url contains args
	* item-status: raise error on lists supplied as filters
	* logging: Debug/Info logic brought to api.system.logger

## Impacted Areas in Application
1. Public REST API: Allows `PUT` method against `order` resource, to supply `"status": "cancelled"`. Opens `pixel_qa` to public. 
1. Production API: Allows `"user": <username>` to be supplied as JSON to handle-orders resource. Returns `False` for scenes already cancelled when trying to advance status to `"processing"` or `"complete"`. 

## Related PRs

branch | PR
------ | ------
rb-2.20.0 | [espa-processing#348](https://github.com/USGS-EROS/espa-processing/pull/348)
2017.June.Dev | [espa-web#78](https://github.com/USGS-EROS/espa-web/pull/78)


## Test Coverage
* Unit tests:
	* 121 tests, all passed
	* Coverage: 71 % overall
	* _Previous Coverage_: 70% overall
