### PR TITLE
LSRD-960: endpoint to re-set the database states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Change Notes
+###### July 2017
+* Add production-api reset queued/processing scene status
 ###### June 2017 
 * Ability to cancel orders
 * Put all errors/warnings in "messages" JSON field

--- a/api/interfaces/production/version1.py
+++ b/api/interfaces/production/version1.py
@@ -162,3 +162,15 @@ class API(object):
             response = default_error_message
         return response
 
+    def reset_processing_status(self):
+        """
+        Handler for killing queued/processing scenes in hadoop
+        :return: true
+        """
+        try:
+            response = self.production.reset_processing_status()
+        except:
+            logger.debug("ERR handling queued/processing scenes\ntrace: {}".format(traceback.format_exc()))
+            response = default_error_message
+        return response
+

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -1362,14 +1362,10 @@ class ProductionProvider(ProductionProviderInterfaceV0):
     @staticmethod
     def reset_processing_status():
         """
-        Kills all hadoop jobs (if found) and resets all scene states
+        Resets all "queued/processing" scene states
 
         :return: bool
         """
-        running_jobs = hadoop_handler.list_jobs()
-        for appid in running_jobs.keys():  # Ignore job-name
-            hadoop_handler.kill_job(appid)
-
         scenes = Scene.where({'status': ('queued', 'processing')})
         Scene.bulk_update([s.id for s in scenes], {'status': 'submitted'})
         return True

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -1358,3 +1358,18 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         logger.info('Re-submitted {} orphaned scenes'.format(len(scenes)))
 
         return True
+
+    @staticmethod
+    def reset_processing_status():
+        """
+        Kills all hadoop jobs (if found) and resets all scene states
+
+        :return: bool
+        """
+        running_jobs = hadoop_handler.list_jobs()
+        for appid in running_jobs.keys():  # Ignore job-name
+            hadoop_handler.kill_job(appid)
+
+        scenes = Scene.where({'status': ('queued', 'processing')})
+        Scene.bulk_update([s.id for s in scenes], {'status': 'submitted'})
+        return True

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -1367,5 +1367,9 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         :return: bool
         """
         scenes = Scene.where({'status': ('queued', 'processing')})
-        Scene.bulk_update([s.id for s in scenes], {'status': 'submitted'})
-        return True
+        if scenes:
+            Scene.bulk_update([s.id for s in scenes], {'status': 'submitted'})
+            return True
+        else:
+            return False
+

--- a/api/transports/http.py
+++ b/api/transports/http.py
@@ -123,7 +123,8 @@ transport_api.add_resource(ProductionStats,
                            '/production-api/v<version>/statistics/<name>')
 
 transport_api.add_resource(ProductionManagement,
-                           '/production-api/v<version>/handle-orphans')
+                           '/production-api/v<version>/handle-orphans',
+                           '/production-api/v<version>/reset-status')
 
 transport_api.add_resource(ProductionConfiguration,
                            '/production-api/v<version>/configuration/<key>')

--- a/api/transports/http_production.py
+++ b/api/transports/http_production.py
@@ -116,3 +116,6 @@ class ProductionManagement(Resource):
         if 'handle-orphans' in request.url:
             resp = espa.catch_orphaned_scenes()
             return prep_response(resp)
+        if 'reset-status' in request.url:
+            resp = espa.reset_processing_status()
+            return prep_response(resp)

--- a/test/test_production_api.py
+++ b/test/test_production_api.py
@@ -647,5 +647,15 @@ class TestProductionAPI(unittest.TestCase):
         new_time = scene.status_modified
         self.assertGreater(new_time, old_time)
 
+    @patch('api.external.hadoop.HadoopHandler.list_jobs', hadoop.jobs_names_ids)
+    @patch('api.external.hadoop.HadoopHandler.kill_job', lambda x,y: True)
+    def test_hadoop_reset_status(self):
+        order_id = self.mock_order.generate_testing_order(self.user_id)
+        scenes = Scene.where({'order_id': order_id})
+        Scene.bulk_update([s.id for s in scenes], {'status': 'processing'})
+        self.assertTrue(production_provider.reset_processing_status())
+        scenes = Scene.where({'order_id': order_id})
+        self.assertEqual({'submitted'}, set([s.status for s in scenes]))
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Production-API endpoint for resetting all "queued/processing" status. Allows for hard-stops of the processing cluster, or debugging hadoop job ingestion/completion issues. 