### PR TITLE
Release Candidate 2017.07

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Change Notes
 ###### July 2017
+* Upgrade remote calls for Hadoop2
 * Add production-api reset queued/processing scene status
 ###### June 2017 
 * Ability to cancel orders

--- a/api/external/hadoop.py
+++ b/api/external/hadoop.py
@@ -50,7 +50,7 @@ class HadoopHandler(object):
         return resp
 
     def slave_ips(self):
-        _stdout = self._remote_cmd("cat ~/bin/hadoop/conf/slaves")['stdout']
+        _stdout = self._remote_cmd("cat ~/bin/hadoop/etc/hadoop/slaves")['stdout']
         _host_list = [str(i).rstrip('\n') for i in _stdout]
         return [socket.gethostbyname(i) for i in _host_list]
 

--- a/api/external/hadoop.py
+++ b/api/external/hadoop.py
@@ -10,7 +10,8 @@ config = ConfigurationProvider()
 class HadoopHandler(object):
 
     def list_jobs(self):
-        return self._remote_cmd('yarn application -appStates RUNNING -list')
+        status = self._remote_cmd('yarn application -appStates RUNNING -list')['stdout']
+        return dict(s.split()[0:2][::-1] for s in status[2:])
 
     def kill_job(self, jobid):
         return self._remote_cmd('hadoop job -kill {}'.format(jobid))

--- a/api/external/hadoop.py
+++ b/api/external/hadoop.py
@@ -13,8 +13,8 @@ class HadoopHandler(object):
         status = self._remote_cmd('yarn application -appStates RUNNING -list')['stdout']
         return dict(s.split()[0:2][::-1] for s in status[2:])
 
-    def kill_job(self, jobid):
-        return self._remote_cmd('hadoop job -kill {}'.format(jobid))
+    def kill_job(self, appid):
+        return self._remote_cmd('yarn application -kill {}'.format(appid))
 
     def kill_user_jobs(self, username):
         _response = dict()

--- a/api/external/hadoop.py
+++ b/api/external/hadoop.py
@@ -10,7 +10,7 @@ config = ConfigurationProvider()
 class HadoopHandler(object):
 
     def list_jobs(self):
-        return self._remote_cmd('hadoop job -list')
+        return self._remote_cmd('yarn application -appStates RUNNING -list')
 
     def kill_job(self, jobid):
         return self._remote_cmd('hadoop job -kill {}'.format(jobid))
@@ -33,13 +33,7 @@ class HadoopHandler(object):
         resp = cache.get(cache_key)
 
         if not resp:
-            cmd = "hadoop job -list | egrep '^job' | awk '{print $1}' | " \
-                  "xargs -n 1 -I {} sh -c \"hadoop job -status {} | " \
-                  "egrep '^tracking' | awk '{print \$3}'\" | " \
-                  "xargs -n 1 -I{} sh -c \" echo -n {} | " \
-                  "sed 's/.*jobid=//'; echo -n ' ';curl -s -XGET {} | " \
-                  "grep 'Job Name' | sed 's/.* //' | sed 's/<br>//'\""
-            _stdout = self._remote_cmd(cmd)['stdout']
+            _stdout = self.list_jobs()['stdout']
             _id_name_list = [str(i).rstrip('\n') for i in _stdout]
             resp = {}
             for ids in _id_name_list:

--- a/api/external/mocks/hadoop.py
+++ b/api/external/mocks/hadoop.py
@@ -8,7 +8,9 @@ def jobs_names_ids(self):
 
 
 def list_jobs(self, cmd):
-    return {'stdout': ['job_201607260910_1879', 'job_201607260910_1875']}
+    return {'stdout': ['Total number of applications (application-types: [] and states: [RUNNING]):1\n',
+                       '                Application-Id      Application-Name        Application-Type          User           Queue                   State      Final-State              Progress                        Tracking-URL\n',
+                       'application_1499729760759_0002  7_10_2017_17_11_2-all-espa_job             MAPREDUCE       SOMEUSER         default                 RUNNING              UNDEFINED                   5% http://HOSTNAME:00000\n']}
 
 
 def slave_ips(self, cmd):

--- a/api/providers/ordering/ordering_provider.py
+++ b/api/providers/ordering/ordering_provider.py
@@ -194,7 +194,7 @@ class OrderingProvider(ProviderInterfaceV0):
         logger.info('Received request to cancel {} from {}'
                     .format(orderid, request_ip_address))
         killable_scene_states = ('submitted', 'oncache', 'onorder', 'queued',
-                                 'error', 'unavailable', 'complete')
+                                 'retry', 'error', 'unavailable', 'complete')
         scenes = order.scenes(sql_dict={'status': killable_scene_states})
         if len(scenes) > 0:
             Scene.bulk_update([s.id for s in scenes], Scene.cancel_opts())

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -162,7 +162,10 @@ class TestHadoopHandler(unittest.TestCase):
     @patch('api.external.hadoop.HadoopHandler._remote_cmd', mockhadoop.list_jobs)
     def test_list_jobs(self):
         resp = self.hadoop.list_jobs()
-        self.assertEqual({'7_10_2017_17_11_2-all-espa_job'}, set(resp))
+        self.assertIsInstance(resp, dict)
+        for key, value in resp.items()
+            self.assertIsInstance(key, str)
+            self.assertIsInstance(value, str)
 
     @patch('api.external.hadoop.HadoopHandler.job_names_ids', mockhadoop.jobs_names_ids)
     def test_job_names_ids(self):

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -163,7 +163,7 @@ class TestHadoopHandler(unittest.TestCase):
     def test_list_jobs(self):
         resp = self.hadoop.list_jobs()
         self.assertIsInstance(resp, dict)
-        for key, value in resp.items()
+        for key, value in resp.items():
             self.assertIsInstance(key, str)
             self.assertIsInstance(value, str)
 

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -162,21 +162,21 @@ class TestHadoopHandler(unittest.TestCase):
     @patch('api.external.hadoop.HadoopHandler._remote_cmd', mockhadoop.list_jobs)
     def test_list_jobs(self):
         resp = self.hadoop.list_jobs()
-        self.assertTrue('stdout' in resp.keys())
+        self.assertEqual({'7_10_2017_17_11_2-all-espa_job'}, set(resp))
 
     @patch('api.external.hadoop.HadoopHandler.job_names_ids', mockhadoop.jobs_names_ids)
     def test_job_names_ids(self):
         resp = self.hadoop.job_names_ids()
-        self.assertTrue(isinstance(resp, dict))
+        self.assertIsInstance(resp, dict)
 
     @patch('api.external.hadoop.HadoopHandler._remote_cmd', mockhadoop.slave_ips)
     def test_slave_ips(self):
         resp = self.hadoop.slave_ips()
-        self.assertTrue(isinstance(resp, list))
+        self.assertIsInstance(resp, list)
         self.assertTrue(len(resp) > 0)
 
     @patch('api.external.hadoop.HadoopHandler.master_ip', mockhadoop.master_ip)
     def test_master_ip(self):
         resp = self.hadoop.master_ip()
-        self.assertTrue(isinstance(resp, str))
+        self.assertIsInstance(resp, str)
         self.assertTrue(len(resp.split('.')) == 4)


### PR DESCRIPTION
## Status
**READY FOR SYSTEM TEST**

## Description
Updates required for hadoop-2.8.0 migration

## Related PRs

branch | PR
------ | ------
rb-2.21.0 | [espa-processing#351](https://github.com/USGS-EROS/espa-processing/pull/351)


## Impacted Areas in Application

* api.external.hadoop: 
  * Update location of hadoop configs (for whitelisting worker nodes)
  * Update deprecated `hadoop` commandline utilities to `yarn`, for handling orphaned jobs/scenes
* ordering_provider: Bugfix to allow cancelling scenes in a retry-state
