### PR TITLE
Feature/codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - ESPA_API_EMAIL_RECEIVE=someone@nowhere.com
 before_install:
 - make docker-deps-up
+cache: pip
 install: 
 - pip install -r setup/requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,12 @@ before_install:
 cache: pip
 install: 
 - pip install -r setup/requirements.txt
+- pip install codecov
 script:
 - "travis_wait 30 sleep 1800 &"
 - "run/runtests"
 after_success:
 #- "/bin/bash deploy"
 - make docker-deps-down
+- codecov
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 
-[![Build Status](https://travis-ci.org/USGS-EROS/espa-api.svg?branch=master)](https://travis-ci.org/USGS-EROS/espa-api)
-
-# espa-api
+# espa-api [![build status][0]][1] [![Codecov branch][2]][3]
 
 This is an API for interacting with the ESPA ordering system. 
 
@@ -114,4 +112,9 @@ For a more detailed list of User API operations, see the
 [Available Resources List](docs/API-RESOURCES-LIST.md). 
 
 For a language-specific (python) example, please see [an API Demo](examples/api_demo.ipynb). 
+
+[0]: https://img.shields.io/travis/USGS-EROS/espa-api/feature/codecov.svg?style=flat-square
+[1]: https://travis-ci.org/USGS-EROS/espa-api
+[2]: https://img.shields.io/codecov/c/github/USGS-EROS/espa-api/feature/codecov.svg?style=flat-square
+[3]: https://codecov.io/gh/USGS-EROS/espa-api
 


### PR DESCRIPTION
Add Unit-Test coverage reports, automatically generated by Travis-CI, and shipped to CodeCov for trending/analysis of test coverage: 

* Example, current branch: https://codecov.io/gh/USGS-EROS/espa-api/branch/feature%2Fcodecov

#### TODO

[ ] - Update branch names in Readme badges, to point to master before merge