### PR TITLE
Release Candidate 2017.11 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Change Notes
 ###### November 2017
-* Changes to Landsat "ST" terminology
+* Changes to Landsat "ST" terminology (staff only)
+* Image extents (below 80N/S) must match +/-3 UTM zones
+* Pixel Resize must match output projection
 ###### October 2017
 * Restrict orders of only Landsat Level-1
 * Add human-readable `title` to objects in JSON order-schema
@@ -8,7 +10,7 @@
 ###### September 2017
 * Modify email if all products in order fail
 ###### August 2017
-* Begin using M2M for input validation (`ESPA_M2M_MODE`)
+* Begin using M2M for input validation
 ###### July 2017
 * Upgrade remote calls for Hadoop2
 * Add production-api reset queued/processing scene status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Change Notes
+###### November 2017
+* Changes to Landsat "ST" terminology
 ###### October 2017
 * Restrict orders of only Landsat Level-1
 * Add human-readable `title` to objects in JSON order-schema

--- a/api/domain/order.py
+++ b/api/domain/order.py
@@ -308,7 +308,7 @@ class Order(object):
              'include_sr_savi': False,  # soil adjusted vegetation
              'include_sr_msavi': False,  # modified soil adjusted veg
              'include_sr_evi': False,  # enhanced vegetation
-             'include_lst': False,  # land surface temperature
+             'include_st': False,  # surface temperature
              'include_solr_index': False,  # solr search index record
              'include_cfmask': False,  # (deprecated) not
              'include_statistics': False}  # should we do stats & plots?
@@ -673,7 +673,7 @@ class OptionsConversion(object):
                 ('include_sr_savi', 'sr_savi', True),
                 ('include_sr_msavi', 'sr_msavi', True),
                 ('include_sr_evi', 'sr_evi', True),
-                ('include_lst', 'lst', True),
+                ('include_st', 'st', True),
                 ('include_cfmask', 'cloud', True),
                 ('include_pixel_qa', 'pixel_qa', True)]
 

--- a/api/domain/products.yaml
+++ b/api/domain/products.yaml
@@ -27,9 +27,9 @@ products:
     category: cdr
     title: "Surface Reflectance"
     rank: 0
-  lst: 
+  st:
     category: cdr
-    title: "Land Surface Temperature"
+    title: "Surface Temperature"
     rank: 1
   swe: 
     category: ecv

--- a/api/domain/products.yaml
+++ b/api/domain/products.yaml
@@ -8,31 +8,31 @@ products:
     title: "Input Products"
     rank: 0
   pixel_qa: 
-    category: lsat
+    category: l2p
     title: "Pixel QA"
-    rank: 2
+    rank: 4
   toa: 
-    category: lsat
+    category: l2p
     title: "Top of Atmosphere Reflectance"
-    rank: 0
+    rank: 2
   bt: 
-    category: lsat
+    category: l2p
     title: "Brightness Temperature"
-    rank: 1
+    rank: 3
   cloud: 
-    category: lsat
+    category: l2p
     title: "Cloud Mask"
     rank: -1
   sr: 
-    category: cdr
+    category: l2p
     title: "Surface Reflectance"
     rank: 0
   st:
-    category: cdr
+    category: l2p
     title: "Surface Temperature"
     rank: 1
   swe: 
-    category: ecv
+    category: l3p
     title: "Dynamic Surface Water Extent"
     rank: 0
   sr_ndvi: 
@@ -72,18 +72,15 @@ categories:
   source:
     title: "Source Products"
     rank: 0
-  cdr:
-    title: "Climate Data Records"
+  l2p:
+    title: "Level-2 Products"
     rank: 1
-  ecv:
-    title: "Essential Climate Variables"
+  l3p:
+    title: "Level-3 Products"
     rank: 2
-  lsat:
-    title: "Other Landsat Level-2 Products"
-    rank: 3
   indices:
     title: "Spectral Indices"
-    rank: 4
+    rank: 3
   stats:
     title: "Plotting & Statistics"
-    rank: 5
+    rank: 4

--- a/api/domain/restricted.yaml
+++ b/api/domain/restricted.yaml
@@ -1,7 +1,7 @@
 ---
 all:
     role:
-        - lst
+        - st
         - swe
         - cloud
         - restricted_prod
@@ -32,11 +32,11 @@ stats:
         - 'sr_ndmi'
         - 'sr_nbr'
         - 'sr_nbr2'
-        - 'lst'
+        - 'st'
 
 olitirs8:
     role:
-        - lst
+        - st
     by_date:
         sr:
             - "< 2016050 | > 2016058"

--- a/api/domain/sensor.py
+++ b/api/domain/sensor.py
@@ -366,7 +366,7 @@ class Landsat(SensorProduct):
 
 class LandsatTM(Landsat):
     """Models Landsat TM only products"""
-    products = [AllProducts.source_metadata, AllProducts.l1, AllProducts.toa, AllProducts.bt, AllProducts.sr, AllProducts.lst, AllProducts.swe,
+    products = [AllProducts.source_metadata, AllProducts.l1, AllProducts.toa, AllProducts.bt, AllProducts.sr, AllProducts.st, AllProducts.swe,
                 AllProducts.sr_ndvi, AllProducts.sr_evi, AllProducts.sr_savi, AllProducts.sr_msavi, AllProducts.sr_ndmi,
                 AllProducts.sr_nbr, AllProducts.sr_nbr2, AllProducts.stats, AllProducts.cloud, AllProducts.pixel_qa]
     lta_name = 'LANDSAT_TM'
@@ -379,7 +379,7 @@ class LandsatTM(Landsat):
 
 class LandsatETM(Landsat):
     """Models Landsat ETM only products"""
-    products = [AllProducts.source_metadata, AllProducts.l1, AllProducts.toa, AllProducts.bt, AllProducts.sr, AllProducts.lst, AllProducts.swe,
+    products = [AllProducts.source_metadata, AllProducts.l1, AllProducts.toa, AllProducts.bt, AllProducts.sr, AllProducts.st, AllProducts.swe,
                 AllProducts.sr_ndvi, AllProducts.sr_evi, AllProducts.sr_savi, AllProducts.sr_msavi, AllProducts.sr_ndmi,
                 AllProducts.sr_nbr, AllProducts.sr_nbr2, AllProducts.stats, AllProducts.cloud, AllProducts.pixel_qa]
     lta_name = 'LANDSAT_ETM_PLUS'
@@ -392,7 +392,7 @@ class LandsatETM(Landsat):
 
 class LandsatOLITIRS(Landsat):
     """Models Landsat OLI/TIRS only products"""
-    products = [AllProducts.source_metadata, AllProducts.l1, AllProducts.toa, AllProducts.bt, AllProducts.sr, AllProducts.lst, AllProducts.swe,
+    products = [AllProducts.source_metadata, AllProducts.l1, AllProducts.toa, AllProducts.bt, AllProducts.sr, AllProducts.st, AllProducts.swe,
                 AllProducts.sr_ndvi, AllProducts.sr_evi, AllProducts.sr_savi, AllProducts.sr_msavi, AllProducts.sr_ndmi,
                 AllProducts.sr_nbr, AllProducts.sr_nbr2, AllProducts.stats, AllProducts.cloud, AllProducts.pixel_qa]
     lta_name = 'LANDSAT_8'

--- a/api/providers/configuration/configuration_provider.py
+++ b/api/providers/configuration/configuration_provider.py
@@ -34,6 +34,15 @@ class ConfigurationProvider(ConfigurationProviderInterfaceV0):
     def configuration_keys(self):
         return self._retrieve_config()
 
+
+    @property
+    def is_m2m_val_enabled(self):
+        return self.get('system.m2m_val_enabled').lower() == 'true'
+
+    @property
+    def is_m2m_url_enabled(self):
+        return self.get('system.m2m_url_enabled').lower() == 'true'
+
     def url_for(self, service_name):
         key = "url.{0}.{1}".format(self.mode, service_name)
         current = self._retrieve_config()

--- a/api/providers/configuration/configuration_provider.py
+++ b/api/providers/configuration/configuration_provider.py
@@ -37,11 +37,11 @@ class ConfigurationProvider(ConfigurationProviderInterfaceV0):
 
     @property
     def is_m2m_val_enabled(self):
-        return self.get('system.m2m_val_enabled').lower() == 'true'
+        return (self.get('system.m2m_val_enabled') or 'False').lower() == 'true'
 
     @property
     def is_m2m_url_enabled(self):
-        return self.get('system.m2m_url_enabled').lower() == 'true'
+        return (self.get('system.m2m_url_enabled') or 'False').lower() == 'true'
 
     def url_for(self, service_name):
         key = "url.{0}.{1}".format(self.mode, service_name)

--- a/api/providers/inventory/inventory_provider.py
+++ b/api/providers/inventory/inventory_provider.py
@@ -6,6 +6,9 @@ from api.external import lta, inventory, lpdaac, nlaps
 from api import InventoryException, InventoryConnectionException
 from api.domain import sensor
 from api.system.logger import ilogger as logger
+from api.providers.configuration.configuration_provider import ConfigurationProvider
+
+config = ConfigurationProvider()
 
 
 class InventoryProviderV0(InventoryInterfaceV0):
@@ -33,21 +36,21 @@ class InventoryProviderV0(InventoryInterfaceV0):
                 lpdaac_ls.extend(order[key]['inputs'])
 
         if lta_ls:
-            if 'LANDSAT' in os.getenv('ESPA_M2M_MODE', '') and inventory.available():
+            if config.is_m2m_val_enabled and inventory.available():
                 results.update(self.check_dmid(lta_ls, contactid))
-            else:
-                if not lta.check_lta_available():
-                    msg = 'Could not connect to LTA data source'
-                    raise InventoryConnectionException(msg)
+            elif lta.check_lta_available():
                 results.update(self.check_LTA(lta_ls))
-        if lpdaac_ls:
-            if 'MODIS' in os.getenv('ESPA_M2M_MODE', '') and inventory.available():
-                results.update(self.check_dmid(lpdaac_ls, contactid))
             else:
-                if not lpdaac.check_lpdaac_available():
-                    msg = 'Could not connect to LPDAAC data source'
-                    raise InventoryConnectionException(msg)
+                msg = 'Could not connect to Landsat data source'
+                raise InventoryConnectionException(msg)
+        if lpdaac_ls:
+            if config.is_m2m_val_enabled and inventory.available():
+                results.update(self.check_dmid(lpdaac_ls, contactid))
+            elif lpdaac.check_lpdaac_available():
                 results.update(self.check_LPDAAC(lpdaac_ls))
+            else:
+                msg = 'Could not connect to MODIS data source'
+                raise InventoryConnectionException(msg)
 
         not_avail = []
         for key, val in results.items():
@@ -63,21 +66,15 @@ class InventoryProviderV0(InventoryInterfaceV0):
         not_avail = nlaps.products_are_nlaps(prod_ls)
         if not_avail:
             raise InventoryException(not_avail)
-        logger.info('@@ VERIFY: FETCH via MACHINE-TO-MACHINE')
         token = inventory.get_cached_session()
-        results = inventory.get_cached_verify_scenes(token, prod_ls)
-        logger.info('@@ VERIFY: COMPLETE via MACHINE-TO-MACHINE')
-        return results
+        return inventory.get_cached_verify_scenes(token, prod_ls)
 
     @staticmethod
     def check_LTA(prod_ls):
         not_avail = nlaps.products_are_nlaps(prod_ls)
         if not_avail:
             raise InventoryException(not_avail)
-        logger.info('@@ VERIFY: FETCH via OrderWrapperService')
-        results = lta.verify_scenes(prod_ls)
-        logger.info('@@ VERIFY: COMPLETE via OrderWrapperService')
-        return results
+        return lta.verify_scenes(prod_ls)
 
     @staticmethod
     def check_LPDAAC(prod_ls):

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -1327,6 +1327,8 @@ class ProductionProvider(ProductionProviderInterfaceV0):
 
         Note: This problem arises from lack of job scheduler grace when e.g. running out of memory
         """
+        if not len(scenes):
+            return
 
         sids = [int(s.id) for s in scenes]
         self.catch_orphaned_scenes()

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -1355,8 +1355,10 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         scenes = Scene.where({'failed_lta_status_update IS NOT': None, 'order_id': pending_orders})
         self.handle_failed_ee_updates(scenes)
 
-        orders = Order.where({'status': 'cancelled',
-                              'completion_email_sent IS': None, 'id': pending_orders})
+        search = {'status': 'cancelled',  'completion_email_sent IS': None}
+        if user:
+                search.update(user_id=user.id)
+        orders = Order.where(search)
         self.handle_cancelled_orders(orders)
 
         scenes = Scene.where({'status': 'submitted', 'sensor_type': 'landsat', 'order_id': pending_orders})[:500]

--- a/api/providers/production/production_provider.py
+++ b/api/providers/production/production_provider.py
@@ -1043,7 +1043,7 @@ class ProductionProvider(ProductionProviderInterfaceV0):
         :return: list
         """
         products_need_check = {
-            'lst': config.url_for('modis.datapool')  # LST requires ASTER GED
+            'st': config.url_for('modis.datapool')  # ST requires ASTER GED
         }
         passed_dep_check = list()
         for s in scene_list:

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -166,29 +166,6 @@ class OrderValidatorV0(validictory.SchemaValidator):
                    ' of 1 pixel'.format(path, fieldname))
             self._errors.append(msg)
 
-    #     if 'image_extents' in self.data_source:
-    #         # Validate UTM zone matches image_extents
-    #         if self.validate_type_object(self.data_source['projection'].get('utm')):
-    #             if not self.validate_type_integer(self.data_source['projection']['utm'].get('zone')):
-    #                 return
-    #             if not self.data_source['image_extents']['units'] == 'dd':
-    #                 return
-    #             cdict = dict(inzone=self.data_source['projection']['utm']['zone'],
-    #                          east=self.data_source['image_extents']['east'],
-    #                          west=self.data_source['image_extents']['west'],
-    #                          zbuffer=3)
-    #             if not self.is_utm_zone_nearby(**cdict):
-    #                 msg = ('image_extents ({east}E,{west}W) are not near the'
-    #                        ' requested UTM zone ({inzone})'
-    #                        .format(**cdict))
-    #                 self._errors.append(msg)
-    #
-    # @staticmethod
-    # def is_utm_zone_nearby(inzone, east, west, zbuffer=3):
-    #     def long2utm(dd_lon):
-    #         return (math.floor((dd_lon + 180) / 6.) % 60) + 1
-    #     return (long2utm(west) - zbuffer) <= inzone <= (long2utm(east) + zbuffer)
-
     @staticmethod
     def calc_extent(xmax, ymax, xmin, ymin, extent_units, resize_units, resize_pixel):
         """Calculate a good estimate of the number of pixels contained

--- a/docs/API-REQUIREMENTS.md
+++ b/docs/API-REQUIREMENTS.md
@@ -11,7 +11,7 @@
   1. Example: Not all Landsat TM/ETM+/OLITIRS scenes can be corrected to surface reflectance, particularly nighttime observations.  
   
 4. **The available output product list varies based on the spatial and temporal characteristics of the input observations.**  
-  1. Example: Land Surface Temperature cannot currently be produced outside of certain geographic extents due to insufficient auxiliary data.  
+  1. Example: Surface Temperature cannot currently be produced outside of certain geographic extents due to insufficient auxiliary data.  
   
 5. **Requests for output customization are captured at the order (not the input observation) level.  These customizations are applied against every ESPA output product in the order.**  
   1. Users may request that their order is reprojected to sinusoidal, albers, UTM, geographic or polar stereographic.  Each projection requires its own set of parameters which must be validated.  

--- a/docs/AVAILABLE-PRODUCTS.md
+++ b/docs/AVAILABLE-PRODUCTS.md
@@ -28,7 +28,7 @@ a request to `https://espa.cr.usgs.gov/api/v1/available-products`
 | MODIS 11A1  | :heavy_check_mark: | :heavy_check_mark: |:heavy_check_mark:|
 
 ### ESPA Higher-Level CDR/ECV Outputs
-|  | TOA | SR | BT | LST | DSWE | CLOUD
+|  | TOA | SR | BT | ST | DSWE | CLOUD
 |:------------- |:------------- |:------------- |:------------- |:------------- |:------------- |:------------- |
 | Landsat 4 TM | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Landsat 5 TM | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/docs/TERMS.md
+++ b/docs/TERMS.md
@@ -16,7 +16,6 @@
 | HTTPS         | Hyper Text Transfer Protocol Secure|
 | JSON          | Javascript Object Notation |
 | LCMAP         | Land Change Monitoring Assessment and Prediction|
-| LST           | Land Surface Temperature |
 | LTA           | Long Term Archive      |
 | LPDAAC        | Land Process Distributed Active Archive |
 | MODIS         | Moderate Resolution Imaging Spectroradiometer |
@@ -29,6 +28,7 @@
 | OLI/TIRS      | Operational Land Imager/Thermal Infrared Sensor |
 | SAVI          | Soil Adjusted Vegetation Index |
 | SR            | Surface Reflectance |
+| ST            | Surface Temperature |
 | TOA           | Top Of Atmosphere |
 | TIRS          | Thermal Infrared Sensor |
 | TM            | Thematic Mapper |

--- a/setup/espadev_espa_unit_test_configuration.sql
+++ b/setup/espadev_espa_unit_test_configuration.sql
@@ -28,6 +28,9 @@ INSERT INTO ordering_configuration (key, value) VALUES
     ('bulk.dev.json.username', 'dummy_username'),
     ('bulk.dev.json.password', 'dummy_password'),
 
+    ('system.m2m_url_enabled', 'False'),
+    ('system.m2m_val_enabled', 'False'),
+
 -- api.external.ers
     ('url.dev.ersapi', 'http://host.com'),
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -166,6 +166,8 @@ class TestValidation(unittest.TestCase):
         for proj in testorders.good_test_projections:
             valid_order = copy.deepcopy(self.base_order)
             valid_order['projection'] = {proj: testorders.good_test_projections[proj]}
+            if 'lonlat' not in valid_order['projection']:
+                valid_order['resize'] = {"pixel_size": 500, "pixel_size_units": "meters"}
 
             try:
                 good = api.validation(valid_order, self.staffuser.username)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -15,6 +15,7 @@ from api.domain.mocks.order import MockOrder
 from api.domain.mocks.user import MockUser
 from api.domain.order import Order
 from api.domain.user import User
+from api.providers.configuration.configuration_provider import ConfigurationProvider
 from api.providers.production.mocks.production_provider import MockProductionProvider
 from api.providers.production.production_provider import ProductionProvider
 from api.external.mocks import lta as mocklta
@@ -25,6 +26,7 @@ from mock import patch
 api = APIv1()
 production_provider = ProductionProvider()
 mock_production_provider = MockProductionProvider()
+cfg = ConfigurationProvider()
 
 
 class TestAPI(unittest.TestCase):
@@ -344,9 +346,9 @@ class TestInventory(unittest.TestCase):
         """
         Check LTA support from the inventory provider
         """
-        os.environ['ESPA_M2M_MODE'] = 'LANDSAT'
+        cfg.put('system.m2m_val_enabled', 'True')
         self.assertIsNone(api.inventory.check(self.lta_order_good))
-        os.environ['ESPA_M2M_MODE'] = ''
+        cfg.put('system.m2m_val_enabled', 'False')
 
     @patch('api.external.lta.requests.post', mocklta.get_verify_scenes_response_invalid)
     @patch('api.external.lta.check_lta_available', lambda: True)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -167,7 +167,7 @@ class TestValidation(unittest.TestCase):
             valid_order = copy.deepcopy(self.base_order)
             valid_order['projection'] = {proj: testorders.good_test_projections[proj]}
             if 'lonlat' not in valid_order['projection']:
-                valid_order['resize'] = {"pixel_size": 500, "pixel_size_units": "meters"}
+                valid_order['resize'] = {"pixel_size": 30, "pixel_size_units": "meters"}
 
             try:
                 good = api.validation(valid_order, self.staffuser.username)

--- a/test/test_production_api.py
+++ b/test/test_production_api.py
@@ -624,7 +624,7 @@ class TestProductionAPI(unittest.TestCase):
                    'include_cfmask': False,
                    'include_customized_source_data': False,
                    'include_dswe': False,
-                   'include_lst': False,
+                   'include_st': False,
                    'include_solr_index': False,
                    'include_source_data': False,
                    'include_source_metadata': False,


### PR DESCRIPTION
## Description
Updates to use surface-temperature terminology, validation for UTM zone and pixel-resize units, auto checks for stuck jobs. 

## Related PRs

branch | PR
------ | ------
rb-2.25.0 | [espa-processing](https://github.com/USGS-EROS/espa-processing/pull/356)

## Deploy Notes

Envvar `ESPA_M2M_MODE` replaced with update to ordering_configuration table

## Impacted Areas in Application

* Changes to Landsat "ST" terminology (staff only)
* Image extents (below 80N/S) must match +/-3 UTM zones
* Pixel Resize must match output projection
* Auto-resubmit long-running hadoop jobs
* Cleanup M2M configurations for switching sources