### PR TITLE
update handling of ndvi orders

### DIFF
--- a/api/domain/restricted.yaml
+++ b/api/domain/restricted.yaml
@@ -118,16 +118,23 @@ vnp09ga:
     role:
         - viirs_ndvi
 
-# This is an order which should go through alternative channels
+# These are orders which should go through alternative channels
 source:
     sensors: [olitirs8_collection, etm7_collection, tm4_collection, tm5_collection,
-    mod09a1, mod09ga, mod09gq, mod09q1, myd09a1, myd09ga, myd09gq, myd09q1,
-    mod13q1, mod13a1, mod13a2, mod13a3, myd13q1, myd13a1, myd13a2, myd13a3,
-    mod11a1, myd11a1,
-    vnp09ga]
+              mod09a1, mod09ga, mod09gq, mod09q1, myd09a1, myd09ga, myd09gq, myd09q1,
+              mod13q1, mod13a1, mod13a2, mod13a3, myd13q1, myd13a1, myd13a2, myd13a3,
+              mod11a1, myd11a1, vnp09ga]
     products: [l1, source_metadata]
     format: gtiff
     custom: [format, image_extents, resize, projection]
     message: >
-        order includes only non-customized archive data please contact
+        order includes non-customized products, please contact
         User Services for other available options
+
+source_daac:
+    sensors: [mod09a1, mod09ga, mod09gq, mod09q1, myd09a1, myd09ga, myd09gq, myd09q1,
+    mod13q1, mod13a1, mod13a2, mod13a3, myd13q1, myd13a1, myd13a2, myd13a3,
+    mod11a1, myd11a1, vnp09ga]
+    ndvi: [mod09ga, myd09ga, vnp09ga]
+    message: >
+        NDVI not available for requested products

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -433,6 +433,16 @@ class OrderValidatorV0(validictory.SchemaValidator):
                     if msg not in self._errors:
                         self._errors.append(msg)
 
+        restr_modis_viirs = self.restricted['source_daac']
+        daac_sensors = restr_modis_viirs['sensors']
+        req_sensors = [s for s in self.data_source.keys() if s in sn.SensorCONST.instances.keys()
+                       and s in daac_sensors]
+        invalid_req = set(req_sensors) - set(restr_modis_viirs['ndvi'])
+        if invalid_req:
+            if 'modis_ndvi' in req_prods or 'viirs_ndvi' in req_prods:
+                msg = restr_modis_viirs['message'].strip()
+                if msg not in self._errors:
+                    self._errors.append(msg)
 
     def validate_oneormoreobjects(self, x, fieldname, schema, path, key_list):
         """Validates that at least one value is present from the list"""

--- a/test/version0_testorders.py
+++ b/test/version0_testorders.py
@@ -111,8 +111,15 @@ def build_base_order():
 
     for acq in sensor_acqids:
         for prefix, label in zip(sensor_acqids[acq][0], sensor_acqids[acq][1]):
-            base[label] = {'inputs': ['{}{}'.format(prefix, acq)],
-                           'products': sn.instance('{}{}'.format(prefix, acq)).products}
+            # We need to avoid any requests for modis_ndvi - this will raise an error since we have
+            # non-NDVI available MODIS products in the base order.  Testing of modis_ndvi
+            # and viirs_ndvi orders is conducted separately in test_api.py
+            if label.startswith('mod') or label.startswith('myd'):
+                base[label] = {'inputs': ['{}{}'.format(prefix, acq)],
+                               'products': ['l1']}
+            else:
+                base[label] = {'inputs': ['{}{}'.format(prefix, acq)],
+                               'products': sn.instance('{}{}'.format(prefix, acq)).products}
 
     # We need to have at least 2 scenes for viirs-related tests to work
     base['vnp09ga'] = {'inputs': ['VNP09GA.A2014245.h10v04.001.2017043103958',


### PR DESCRIPTION
  - do not allow orders for modis/viirs ndvi if
    the order contains modis/viirs products
    other than the daily 500-m SR
  - added additional testing to verify ndvi ordering
    restrictions
  - updated restricted.yaml to assist with ndvi
    order validation