### PR TITLE
updates for order restrictions

### DIFF
--- a/api/domain/restricted.yaml
+++ b/api/domain/restricted.yaml
@@ -120,10 +120,7 @@ vnp09ga:
 
 # These are orders which should go through alternative channels
 source:
-    sensors: [olitirs8_collection, etm7_collection, tm4_collection, tm5_collection,
-              mod09a1, mod09ga, mod09gq, mod09q1, myd09a1, myd09ga, myd09gq, myd09q1,
-              mod13q1, mod13a1, mod13a2, mod13a3, myd13q1, myd13a1, myd13a2, myd13a3,
-              mod11a1, myd11a1, vnp09ga]
+    sensors: [olitirs8_collection, etm7_collection, tm4_collection, tm5_collection]
     products: [l1, source_metadata]
     format: gtiff
     custom: [format, image_extents, resize, projection]
@@ -133,8 +130,19 @@ source:
 
 source_daac:
     sensors: [mod09a1, mod09ga, mod09gq, mod09q1, myd09a1, myd09ga, myd09gq, myd09q1,
-    mod13q1, mod13a1, mod13a2, mod13a3, myd13q1, myd13a1, myd13a2, myd13a3,
-    mod11a1, myd11a1, vnp09ga]
-    ndvi: [mod09ga, myd09ga, vnp09ga]
+              mod13q1, mod13a1, mod13a2, mod13a3, myd13q1, myd13a1, myd13a2, myd13a3,
+              mod11a1, myd11a1, vnp09ga]
+    products: [l1]
+    format: hdf-eos2
+    custom: [format, image_extents, resize, projection]
+    message: >
+        order includes non-customized products, please contact
+        User Services for other available options
+
+source_modis_ndvi:
+    modis_sensors: [mod09a1, mod09ga, mod09gq, mod09q1, myd09a1, myd09ga, myd09gq, myd09q1,
+                    mod13q1, mod13a1, mod13a2, mod13a3, myd13q1, myd13a1, myd13a2, myd13a3,
+                    mod11a1, myd11a1]
+    ndvi_sensors: [mod09ga, myd09ga]
     message: >
         NDVI not available for requested products

--- a/api/providers/validation/validictory.py
+++ b/api/providers/validation/validictory.py
@@ -359,6 +359,13 @@ class OrderValidatorV0(validictory.SchemaValidator):
         if not req_prods:
             return
 
+        try:
+            req_scene = x.get('inputs')[0]
+        except IndexError:
+            return
+
+        inst = sn.instance(req_scene)
+
         avail_prods = (ordering.OrderingProvider()
                        .available_products(x['inputs'], self.username))
 
@@ -421,28 +428,46 @@ class OrderValidatorV0(validictory.SchemaValidator):
                            .format(d, path.split('.products')[0], scene_ids))
                     self._errors.append(msg)
 
+        # Enforce non-customized l1 ordering restriction for Landsat
         restr_source = self.restricted['source']
-        sensors = [s for s in self.data_source.keys() if s in sn.SensorCONST.instances.keys()]
-        other_sensors = set(sensors) - set(restr_source['sensors'])
-        parse_customize = lambda c: ((c in self.data_source) and
-                                     (self.data_source.get(c) != restr_source.get(c)))
-        if not other_sensors:
+        landsat_sensors = restr_source['sensors']
+        sensors = [s for s in self.data_source.keys() if s in sn.SensorCONST.instances.keys() and
+                   s in landsat_sensors]
+        parse_customize = lambda c: ((c in self.data_source)
+                                     and (self.data_source.get(c) != restr_source.get(c)))
+        if sensors and 'LANDSAT' in inst.lta_json_name:
             if not set(req_prods) - set(restr_source['products']):
                 if not any(map(parse_customize, restr_source['custom'])):
                     msg = restr_source['message'].strip()
                     if msg not in self._errors:
                         self._errors.append(msg)
 
+        # Enforce non-customized l1 ordering restriction for MODIS and VIIRS
         restr_modis_viirs = self.restricted['source_daac']
-        daac_sensors = restr_modis_viirs['sensors']
-        req_sensors = [s for s in self.data_source.keys() if s in sn.SensorCONST.instances.keys()
-                       and s in daac_sensors]
-        invalid_req = set(req_sensors) - set(restr_modis_viirs['ndvi'])
-        if invalid_req:
-            if 'modis_ndvi' in req_prods or 'viirs_ndvi' in req_prods:
-                msg = restr_modis_viirs['message'].strip()
-                if msg not in self._errors:
-                    self._errors.append(msg)
+        modis_viirs_sensors = restr_modis_viirs['sensors']
+        sensors_mv = [s for s in self.data_source.keys() if s in sn.SensorCONST.instances.keys()
+                      and s in modis_viirs_sensors]
+        parse_modis_customize = lambda c: ((c in self.data_source)
+                                           and (self.data_source.get(c) != restr_modis_viirs.get(c)))
+        if sensors_mv and ('MODIS' in inst.lta_json_name or 'VIIRS' in inst.lta_json_name):
+            if not set(req_prods) - set(restr_modis_viirs['products']):
+                if not any(map(parse_modis_customize, restr_modis_viirs['custom'])):
+                    msg = restr_modis_viirs['message'].strip()
+                    if msg not in self._errors:
+                        self._errors.append(msg)
+
+        # Enforce restricted product ordering for MODIS NDVI
+        if 'MODIS' in inst.lta_json_name:
+            restr_modis_ndvi = self.restricted['source_modis_ndvi']
+            modis_sensors = restr_modis_ndvi['modis_sensors']
+            req_ndvi_sensors = [s for s in self.data_source.keys() if s in sn.SensorCONST.instances.keys()
+                                and s in modis_sensors]
+            invalid_req = set(req_ndvi_sensors) - set(restr_modis_ndvi['ndvi_sensors'])
+            if invalid_req:
+                if 'modis_ndvi' in req_prods:
+                    msg = restr_modis_ndvi['message'].strip()
+                    if msg not in self._errors:
+                        self._errors.append(msg)
 
     def validate_oneormoreobjects(self, x, fieldname, schema, path, key_list):
         """Validates that at least one value is present from the list"""

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -343,11 +343,23 @@ class TestValidation(unittest.TestCase):
             },
 
             {
+                "mod09ga": {
+                    "inputs": ["mod09ga.a2017249.h29v10.006.2016256236022"],
+                    "products": ["l1"]
+                },
+                "olitirs8_collection": {
+                    "inputs": ["lc08_l1tp_015035_20140713_20170304_01_t1"],
+                    "products": ["sr"]
+                },
+                "format": "hdf-eos2"
+            },
+
+            {
                 "vnp09ga": {
                     "inputs": ["vnp09ga.a2017249.h19v06.001.2016265235022"],
                     "products": ["l1"],
                 },
-                "format": "gtiff"
+                "format": "hdf-eos2"
             }
         ]
         for iorder in invalid_orders:
@@ -389,11 +401,34 @@ class TestValidation(unittest.TestCase):
             },
 
             {
+                "projection": {
+                    "aea": {
+                        "standard_parallel_1": 29.5,
+                        "central_meridian": -96,
+                        "datum": "wgs84",
+                        "latitude_of_origin": 23,
+                        "standard_parallel_2": 45.5,
+                        "false_northing": 0,
+                        "false_easting": 0
+                    }
+                },
+                "olitirs8_collection": {
+                    "inputs": ["lc08_l1tp_015035_20140713_20170304_01_t1"],
+                    "products": ["l1"]
+                },
+                "myd13a2": {
+                    "inputs": ["myd13a2.a2017249.h19v06.006.2017265235022"],
+                    "products": ["l1"]
+                },
+                "format": "hdf-eos2"
+            },
+
+            {
                 "vnp09ga": {
                     "inputs": ["vnp09ga.a2017249.h19v06.001.2016265235022"],
                     "products": ["viirs_ndvi"],
                 },
-                "format": "gtiff"
+                "format": "hdf-eos2"
             }
         ]
         for vorder in valid_orders:
@@ -408,7 +443,7 @@ class TestValidation(unittest.TestCase):
 
     def test_modis_viirs_ndvi_restricted(self):
         """ Users should only be able to order NDVI for
-        Daily Surface Reflectance 500-m MODIS and VIIRS products """
+        Daily Surface Reflectance 500-m MODIS products """
         invalid_orders = [
             {
                 "projection": {
@@ -426,9 +461,9 @@ class TestValidation(unittest.TestCase):
                     "inputs": ["myd13a2.a2017249.h19v06.006.2017265235022"],
                     "products": ["l1"]
                 },
-                "vnp09ga": {
-                    "inputs": ["vnp09ga.a2017249.h19v06.001.2016265235022"],
-                    "products": ["viirs_ndvi"],
+                "mod09ga": {
+                    "inputs": ["mod09ga.a2017249.h29v10.006.2016256236022"],
+                    "products": ["modis_ndvi"]
                 },
                 "format": "gtiff"
             },
@@ -453,10 +488,6 @@ class TestValidation(unittest.TestCase):
                     "inputs": ["myd09ga.a2017249.h19v06.006.2017265235022"],
                     "products": ["modis_ndvi"]
                 },
-                "mod09ga": {
-                    "inputs": ["myd13a2.a2017249.h19v06.006.2017265235022"],
-                    "products": ["modis_ndvi"]
-                },
                 "vnp09ga": {
                     "inputs": ["vnp09ga.a2017249.h19v06.001.2016265235022"],
                     "products": ["viirs_ndvi"]
@@ -474,6 +505,18 @@ class TestValidation(unittest.TestCase):
                 "myd09ga": {
                     "inputs": ["myd09ga.a2017249.h19v06.006.2017265235022"],
                     "products": ["modis_ndvi"]
+                },
+                "vnp09ga": {
+                    "inputs": ["vnp09ga.a2017249.h19v06.001.2016265235022"],
+                    "products": ["viirs_ndvi"],
+                },
+                "format": "gtiff"
+            },
+
+            {
+                "myd13a2": {
+                    "inputs": ["myd13a2.a2017249.h19v06.006.2017265235022"],
+                    "products": ["l1"]
                 },
                 "vnp09ga": {
                     "inputs": ["vnp09ga.a2017249.h19v06.001.2016265235022"],


### PR DESCRIPTION
  - handle Landsat and Modis/Viirs customization separately
  - consider hdf-eos2 non-customized format for Modis/Viirs
  - consider geotiff non-customized format for Landsat
  - don't restrict Viirs NDVI ordering since VNP09GA is the only
    available VIIRS product in ESPA
  - update tests to handle new sensor-specific formats