### PR TITLE
remove staff role for modis/viirs daily ndvi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,7 @@ docker-deps-down-nuke:
 	docker-compose -f setup/docker-compose.yml down
 	docker network rm backend
 	docker image rm setup_postgres:latest
-	docker volume prune -f
-	docker system prune -f
+	docker system prune -f --volumes
 
 deploy-pypi:
 

--- a/api/domain/restricted.yaml
+++ b/api/domain/restricted.yaml
@@ -106,18 +106,6 @@ tm4:
         - reanalsrc_fp
         - reanalsrc_fpit
 
-mod09ga:
-    role:
-        - modis_ndvi
-
-myd09ga:
-    role:
-        - modis_ndvi
-
-vnp09ga:
-    role:
-        - viirs_ndvi
-
 # These are orders which should go through alternative channels
 source:
     sensors: [olitirs8_collection, etm7_collection, tm4_collection, tm5_collection]

--- a/api/providers/ordering/ordering_provider.py
+++ b/api/providers/ordering/ordering_provider.py
@@ -78,12 +78,15 @@ class OrderingProvider(ProviderInterfaceV0):
             outs = pub_prods[sensor_type]['products']
             ins = pub_prods[sensor_type]['inputs']
 
+            ### Leaving this here as it could be a useful template
+            ### if we introduce new sensors in the future which are
+            ### role restricted.
             # Restrict ordering VIIRS to staff
-            if role and sensor_type.startswith('vnp'):
-                for sc_id in ins:
-                    upd['not_implemented'].append(sc_id)
-                pub_prods.pop(sensor_type)
-                continue
+            # if role and sensor_type.startswith('vnp'):
+            #     for sc_id in ins:
+            #         upd['not_implemented'].append(sc_id)
+            #     pub_prods.pop(sensor_type)
+            #     continue
 
             if sensor_type in all_ordering_rsctd:
                 for sc_id in ins:


### PR DESCRIPTION
This updates the API to make ordering MODIS/VIIRS daily NDVI publicly available (also VIIRS daily SR product)